### PR TITLE
Always try to create a bucket when loading a container

### DIFF
--- a/storage/stow_store.go
+++ b/storage/stow_store.go
@@ -127,7 +127,7 @@ type StowStore struct {
 }
 
 func (s *StowStore) LoadContainer(ctx context.Context, container string, createIfNotFound bool) (stow.Container, error) {
-	// TODO: As of stow v0.2.7 a buggy commit [https://github.com/graymeta/stow/commit/0862eee499c9e7b87763e9f30af7b99479177ec5#diff-dd65194c93a22b03112f6701be7b9ad784706bdb374cc5b2d9f8ffe56b480564R174]
+	// TODO: As of stow v0.2.6 a buggy commit [https://github.com/graymeta/stow/commit/0862eee499c9e7b87763e9f30af7b99479177ec5#diff-dd65194c93a22b03112f6701be7b9ad784706bdb374cc5b2d9f8ffe56b480564R174]
 	// which elides the container lookup when a bucket region is set, which means we can't use the error from the
 	// commented line below to test for the existence of a container. Instead we always just create it when createIfNotFound is true.
 	// c, err := s.loc.Container(container)

--- a/storage/stow_store.go
+++ b/storage/stow_store.go
@@ -53,22 +53,6 @@ var fQNFn = map[string]func(string) DataReference{
 	},
 }
 
-// Checks if the error is AWS S3 bucket not found error
-// TODO: uncomment this out when stow correctly returns a fetched container in the case a bucket region is set.
-/*
-func awsBucketIsNotFound(err error) bool {
-	if IsNotFound(err) {
-		return true
-	}
-
-	if awsErr, errOk := errs.Cause(err).(awserr.Error); errOk {
-		return awsErr.Code() == s32.ErrCodeNoSuchBucket
-	}
-
-	return false
-}
-*/
-
 // Checks if the error is AWS S3 bucket already exists error.
 func awsBucketAlreadyExists(err error) bool {
 	if IsExists(err) {
@@ -127,10 +111,8 @@ type StowStore struct {
 }
 
 func (s *StowStore) LoadContainer(ctx context.Context, container string, createIfNotFound bool) (stow.Container, error) {
-	// TODO: As of stow v0.2.6 a buggy commit [https://github.com/graymeta/stow/commit/0862eee499c9e7b87763e9f30af7b99479177ec5#diff-dd65194c93a22b03112f6701be7b9ad784706bdb374cc5b2d9f8ffe56b480564R174]
-	// which elides the container lookup when a bucket region is set, which means we can't use the error from the
-	// commented line below to test for the existence of a container. Instead we always just create it when createIfNotFound is true.
-	// c, err := s.loc.Container(container)
+	// TODO: As of stow v0.2.6 elides the container lookup when a bucket region is set,
+	// so we always just attempt to create it when createIfNotFound is true.
 
 	if createIfNotFound {
 		logger.Infof(ctx, "Attempting to create container [%s]", container)

--- a/storage/stow_store_test.go
+++ b/storage/stow_store_test.go
@@ -402,3 +402,44 @@ func Test_newStowRawStore(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadContainer(t *testing.T) {
+	t.Run("Create if not found", func(t *testing.T) {
+		container := "container"
+		stowStore := StowStore{
+			loc: &mockStowLoc{
+				ContainerCb: func(id string) (stow.Container, error) {
+					if id == container {
+						return newMockStowContainer(container), nil
+					}
+					return nil, fmt.Errorf("container is not supported")
+				},
+				CreateContainerCb: func(name string) (stow.Container, error) {
+					if name == container {
+						return newMockStowContainer(container), nil
+					}
+					return nil, fmt.Errorf("container is not supported")
+				},
+			},
+		}
+		stowContainer, err := stowStore.LoadContainer(context.Background(), "container", true)
+		assert.NoError(t, err)
+		assert.Equal(t, container, stowContainer.ID())
+	})
+	t.Run("No create if not found", func(t *testing.T) {
+		container := "container"
+		stowStore := StowStore{
+			loc: &mockStowLoc{
+				ContainerCb: func(id string) (stow.Container, error) {
+					if id == container {
+						return newMockStowContainer(container), nil
+					}
+					return nil, fmt.Errorf("container is not supported")
+				},
+			},
+		}
+		stowContainer, err := stowStore.LoadContainer(context.Background(), "container", false)
+		assert.NoError(t, err)
+		assert.Equal(t, container, stowContainer.ID())
+	})
+}

--- a/storage/stow_store_test.go
+++ b/storage/stow_store_test.go
@@ -28,11 +28,16 @@ import (
 
 type mockStowLoc struct {
 	stow.Location
-	ContainerCb func(id string) (stow.Container, error)
+	ContainerCb       func(id string) (stow.Container, error)
+	CreateContainerCb func(name string) (stow.Container, error)
 }
 
 func (m mockStowLoc) Container(id string) (stow.Container, error) {
 	return m.ContainerCb(id)
+}
+
+func (m mockStowLoc) CreateContainer(name string) (stow.Container, error) {
+	return m.CreateContainerCb(name)
 }
 
 type mockStowContainer struct {
@@ -133,6 +138,12 @@ func TestStowStore_ReadRaw(t *testing.T) {
 				}
 				return nil, fmt.Errorf("container is not supported")
 			},
+			CreateContainerCb: func(name string) (stow.Container, error) {
+				if name == container {
+					return newMockStowContainer(container), nil
+				}
+				return nil, fmt.Errorf("container is not supported")
+			},
 		}, false, testScope)
 		assert.NoError(t, err)
 		err = s.WriteRaw(context.TODO(), DataReference("s3://container/path"), 0, Options{}, bytes.NewReader([]byte{}))
@@ -154,6 +165,12 @@ func TestStowStore_ReadRaw(t *testing.T) {
 		s, err := NewStowRawStore(fn(container), &mockStowLoc{
 			ContainerCb: func(id string) (stow.Container, error) {
 				if id == container {
+					return newMockStowContainer(container), nil
+				}
+				return nil, fmt.Errorf("container is not supported")
+			},
+			CreateContainerCb: func(name string) (stow.Container, error) {
+				if name == container {
 					return newMockStowContainer(container), nil
 				}
 				return nil, fmt.Errorf("container is not supported")
@@ -183,6 +200,12 @@ func TestStowStore_ReadRaw(t *testing.T) {
 				}
 				return nil, fmt.Errorf("container is not supported")
 			},
+			CreateContainerCb: func(name string) (stow.Container, error) {
+				if name == container {
+					return newMockStowContainer(container), nil
+				}
+				return nil, fmt.Errorf("container is not supported")
+			},
 		}, true, testScope)
 		assert.NoError(t, err)
 		err = s.WriteRaw(context.TODO(), "s3://bad-container/path", 0, Options{}, bytes.NewReader([]byte{}))
@@ -205,6 +228,12 @@ func TestStowStore_ReadRaw(t *testing.T) {
 		s, err := NewStowRawStore(fn(container), &mockStowLoc{
 			ContainerCb: func(id string) (stow.Container, error) {
 				if id == container {
+					return newMockStowContainer(container), nil
+				}
+				return nil, fmt.Errorf("container is not supported")
+			},
+			CreateContainerCb: func(name string) (stow.Container, error) {
+				if name == container {
 					return newMockStowContainer(container), nil
 				}
 				return nil, fmt.Errorf("container is not supported")


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katrogan9@gmail.com>

# TL;DR
Stow [v0.2.6](https://github.com/graymeta/stow/releases/tag/v0.2.6) changes stow s3 location Container behavior [to elide container lookup](https://github.com/graymeta/stow/commit/0862eee499c9e7b87763e9f30af7b99479177ec5#diff-dd65194c93a22b03112f6701be7b9ad784706bdb374cc5b2d9f8ffe56b480564R174) when a region is set.


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Discovered while upgrading flyteadmin and integration tests broke

## Tracking Issue
https://github.com/flyteorg/flyte/issues/815

## Follow-up issue
_NA_
