### PR TITLE
Added home dir ~/.flyte in search path

### DIFF
--- a/config/files/finder.go
+++ b/config/files/finder.go
@@ -13,7 +13,15 @@ const (
 var configLocations = [][]string{
 	{"."},
 	{"/etc", "flyte", "config"},
+	{UserHomeDir(), ".flyte"},
 	{os.ExpandEnv("$GOPATH"), "src", "github.com", "lyft", "flytestdlib"},
+}
+var osUserHomDir = os.UserHomeDir
+// UserHomeDir Returns the users home directory or on error returns the current dir
+func UserHomeDir() string {
+	homeDir := "."
+	homeDir, _ = osUserHomDir()
+	return homeDir
 }
 
 // Check if File / Directory Exists

--- a/config/files/finder_test.go
+++ b/config/files/finder_test.go
@@ -1,12 +1,17 @@
 package files
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	homeDirVal = "/home/user"
+	homeDirErr error
+)
 func TestFindConfigFiles(t *testing.T) {
 	t.Run("Find config-* group", func(t *testing.T) {
 		files := FindConfigFiles([]string{filepath.Join("testdata", "config*.yaml")})
@@ -24,5 +29,26 @@ func TestFindConfigFiles(t *testing.T) {
 
 		files = FindConfigFiles([]string{filepath.Join("testdata", "other-group-3.yaml")})
 		assert.Equal(t, 0, len(files))
+	})
+}
+
+func FakeUserHomeDir() (string, error) {
+	return homeDirVal, homeDirErr
+}
+func TestUserHomeDir(t *testing.T) {
+	t.Run("User home dir", func(t *testing.T) {
+		osUserHomDir = FakeUserHomeDir
+		homeDir := UserHomeDir()
+		assert.Equal(t, homeDirVal, homeDir)
+	})
+	t.Run("User home dir fail", func(t *testing.T) {
+		homeDirErr = fmt.Errorf("failed to get users home directory")
+		homeDirVal = "."
+		osUserHomDir = FakeUserHomeDir
+		homeDir := UserHomeDir()
+		assert.Equal(t, ".", homeDir)
+		// Reset
+		homeDirErr = nil
+		homeDirVal = "/home/user"
 	})
 }


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Currently the config.yaml file is searched in the following locations.

- currentDir
- /etc/flyte/config
- $GOPATH/src/github.com/lyft/flytestdlib

To make it compatible with flytekit we should also add homedir/.flyte directory to search path.



## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/941

## Follow-up issue
_NA_