### PR TITLE
Zero fields overriden in config files to avoid undesired merging logic

### DIFF
--- a/config/tests/accessor_test.go
+++ b/config/tests/accessor_test.go
@@ -299,6 +299,38 @@ func TestAccessor_UpdateConfig(t *testing.T) {
 			assert.Equal(t, 4, (*topLevel)[1].IntValue)
 		})
 
+		t.Run(fmt.Sprintf("[%v] Override default array config", provider(config.Options{}).ID()), func(t *testing.T) {
+			root := config.NewRootSection()
+			_, err := root.RegisterSection(MyComponentSectionKey, &ItemArray{
+				Items: []Item{
+					{
+						ID:   "default_1",
+						Name: "default_Name",
+					},
+					{
+						ID:   "default_2",
+						Name: "default_2_Name",
+					},
+				},
+				OtherItem: Item{
+					ID:   "default_3",
+					Name: "default_3_name",
+				},
+			})
+			assert.NoError(t, err)
+
+			v := provider(config.Options{
+				SearchPaths: []string{filepath.Join("testdata", "array_config_2.yaml")},
+				RootSection: root,
+			})
+
+			assert.NoError(t, v.UpdateConfig(context.TODO()))
+			r := root.GetSection(MyComponentSectionKey).GetConfig().(*ItemArray)
+			assert.Len(t, r.Items, 1)
+			assert.Equal(t, "abc", r.Items[0].ID)
+			assert.Equal(t, "default_3", r.OtherItem.ID)
+		})
+
 		t.Run(fmt.Sprintf("[%v] Override in Env Var", provider(config.Options{}).ID()), func(t *testing.T) {
 			reg := config.NewRootSection()
 			_, err := reg.RegisterSection(MyComponentSectionKey, &MyComponentConfig{})

--- a/config/tests/testdata/array_config_2.yaml
+++ b/config/tests/testdata/array_config_2.yaml
@@ -1,0 +1,4 @@
+my-component:
+  items:
+    - id: abc
+      name: "A b c"

--- a/config/tests/types_test.go
+++ b/config/tests/types_test.go
@@ -27,6 +27,16 @@ type OtherComponentConfig struct {
 	StringArrayWithDefaults []string        `json:"strings-def"`
 }
 
+type Item struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type ItemArray struct {
+	Items     []Item `json:"items"`
+	OtherItem Item   `json:"otherItem"`
+}
+
 func (MyComponentConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("MyComponentConfig", pflag.ExitOnError)
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "str"), "hello world", "life is short")

--- a/config/viper/viper.go
+++ b/config/viper/viper.go
@@ -270,6 +270,8 @@ func defaultDecoderConfig(output interface{}, opts ...viperLib.DecoderConfigOpti
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
 		),
+		// Empty/zero fields before applying provided values. This avoids potentially undesired/unexpected merging logic.
+		ZeroFields: true,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
The default behavior for the mapstructure package used to merge new and default configs is to merge maps by setting all keys and to merge arrays by replacing the first n elements with the new n elements while leaving the rest intact.

The intuitive behavior, talking to users, is that when a field is set in a config, it completely replaces the default config.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Complete description
There is a ZeroFields setting to be set in the decoder used. It only zeros fields that are being replaced from the config file and not just all fields...

## Tracking Issue
https://github.com/flyteorg/flyte/issues/948