### PR TITLE
stdlibConfig strictMode should not fail if there are existing flags

### DIFF
--- a/config/tests/accessor_test.go
+++ b/config/tests/accessor_test.go
@@ -207,6 +207,25 @@ func TestStrictAccessor(t *testing.T) {
 			assert.Error(t, v.UpdateConfig(context.TODO()))
 		})
 
+		t.Run(fmt.Sprintf("[%v] flags defined outside", provider(config.Options{}).ID()), func(t *testing.T) {
+			reg := config.NewRootSection()
+			_, err := reg.RegisterSection(MyComponentSectionKey, &MyComponentConfig{})
+			assert.NoError(t, err)
+
+			_, err = reg.RegisterSection(OtherComponentSectionKey, &OtherComponentConfig{})
+			assert.NoError(t, err)
+			v := provider(config.Options{
+				StrictMode:  true,
+				SearchPaths: []string{filepath.Join("testdata", "bad_config.yaml")},
+				RootSection: reg,
+			})
+
+			set := pflag.NewFlagSet("test", pflag.ExitOnError)
+			set.String("unknown-key", "", "")
+			v.InitializePflags(set)
+			assert.NoError(t, v.UpdateConfig(context.TODO()))
+		})
+
 		t.Run(fmt.Sprintf("[%v] Set through env", provider(config.Options{}).ID()), func(t *testing.T) {
 			reg := config.NewRootSection()
 			_, err := reg.RegisterSection(MyComponentSectionKey, &MyComponentConfig{})

--- a/config/tests/accessor_test.go
+++ b/config/tests/accessor_test.go
@@ -221,7 +221,7 @@ func TestStrictAccessor(t *testing.T) {
 			})
 
 			set := pflag.NewFlagSet("test", pflag.ExitOnError)
-			set.String("unknown-key", "", "")
+			set.StringP("unknown-key", "u", "", "")
 			v.InitializePflags(set)
 			assert.NoError(t, v.UpdateConfig(context.TODO()))
 		})

--- a/config/tests/testdata/bad_config.yaml
+++ b/config/tests/testdata/bad_config.yaml
@@ -5,9 +5,9 @@ other-component:
   int-val: 4
   string-value: Hey there!
   strings:
-  - hello
-  - world
-  - '!'
+    - hello
+    - world
+    - '!'
   url-value: http://something.com
-  unknown-key: "something"
+unknown-key: "something"
 


### PR DESCRIPTION
# TL;DR
Update `strictMode` to capture existing flags in a flagset before parsing params. This way it can avoid failing when there are flags defined outside of stdlibConfig world.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/1209