### PR TITLE
Added exclude-marshal-fns flag to exclude the generated marshal functions

### DIFF
--- a/cli/pflags/api/generator.go
+++ b/cli/pflags/api/generator.go
@@ -20,10 +20,10 @@ const (
 
 // PFlagProviderGenerator parses and generates GetPFlagSet implementation to add PFlags for a given struct's fields.
 type PFlagProviderGenerator struct {
-	pkg                  *types.Package
-	st                   *types.Named
-	defaultVar           *types.Var
-	shouldBindDefaultVar bool
+	pkg                     *types.Package
+	st                      *types.Named
+	defaultVar              *types.Var
+	shouldBindDefaultVar    bool
 	shouldDisableMarshalFns bool
 }
 
@@ -236,14 +236,14 @@ func discoverFieldsRecursive(ctx context.Context, typ *types.Named, defaultValue
 			}
 
 			fields = append(fields, FieldInfo{
-				Name:                    tag.Name,
-				GoName:                  v.Name(),
-				Typ:                     t,
-				FlagMethodName:          camelCase(t.String()),
-				DefaultValue:            defaultValue,
-				UsageString:             tag.Usage,
-				TestValue:               `"1"`,
-				TestStrategy:            JSON,
+				Name:           tag.Name,
+				GoName:         v.Name(),
+				Typ:            t,
+				FlagMethodName: camelCase(t.String()),
+				DefaultValue:   defaultValue,
+				UsageString:    tag.Usage,
+				TestValue:      `"1"`,
+				TestStrategy:   JSON,
 			})
 		case *types.Named:
 			if _, isStruct := t.Underlying().(*types.Struct); !isStruct {
@@ -290,6 +290,7 @@ func discoverFieldsRecursive(ctx context.Context, typ *types.Named, defaultValue
 					UsageString:       tag.Usage,
 					TestValue:         testValue,
 					TestStrategy:      JSON,
+					ShouldBindDefault: bindDefaultVar,
 				})
 			} else {
 				logger.Infof(ctx, "Traversing fields in type.")
@@ -309,6 +310,7 @@ func discoverFieldsRecursive(ctx context.Context, typ *types.Named, defaultValue
 						UsageString:       subField.UsageString,
 						TestValue:         subField.TestValue,
 						TestStrategy:      subField.TestStrategy,
+						ShouldBindDefault: bindDefaultVar,
 					})
 				}
 			}
@@ -402,10 +404,10 @@ func NewGenerator(pkg, targetTypeName, defaultVariableName string, shouldBindDef
 	}
 
 	return &PFlagProviderGenerator{
-		st:                   st,
-		pkg:                  targetPackage,
-		defaultVar:           defaultVar,
-		shouldBindDefaultVar: shouldBindDefaultVar,
+		st:                      st,
+		pkg:                     targetPackage,
+		defaultVar:              defaultVar,
+		shouldBindDefaultVar:    shouldBindDefaultVar,
 		shouldDisableMarshalFns: shouldDisableMarshalFns,
 	}, nil
 }

--- a/cli/pflags/api/pflag_provider.go
+++ b/cli/pflags/api/pflag_provider.go
@@ -15,6 +15,7 @@ import (
 type PFlagProvider struct {
 	typeName string
 	pkg      *types.Package
+	shouldDisableMarshalFns bool
 	fields   []FieldInfo
 }
 
@@ -81,10 +82,11 @@ func (p PFlagProvider) generate(generator func(buffer *bytes.Buffer, info TypeIn
 	return err
 }
 
-func newPflagProvider(pkg *types.Package, typeName string, fields []FieldInfo) PFlagProvider {
+func newPflagProvider(pkg *types.Package, typeName string, fields []FieldInfo, shouldDisableMarshalFns bool) PFlagProvider {
 	return PFlagProvider{
 		typeName: typeName,
 		pkg:      pkg,
 		fields:   fields,
+		shouldDisableMarshalFns: shouldDisableMarshalFns,
 	}
 }

--- a/cli/pflags/api/pflag_provider.go
+++ b/cli/pflags/api/pflag_provider.go
@@ -13,10 +13,10 @@ import (
 )
 
 type PFlagProvider struct {
-	typeName string
-	pkg      *types.Package
+	typeName                string
+	pkg                     *types.Package
 	shouldDisableMarshalFns bool
-	fields   []FieldInfo
+	fields                  []FieldInfo
 }
 
 // Adds any needed imports for types not directly declared in this package.
@@ -84,9 +84,9 @@ func (p PFlagProvider) generate(generator func(buffer *bytes.Buffer, info TypeIn
 
 func newPflagProvider(pkg *types.Package, typeName string, fields []FieldInfo, shouldDisableMarshalFns bool) PFlagProvider {
 	return PFlagProvider{
-		typeName: typeName,
-		pkg:      pkg,
-		fields:   fields,
+		typeName:                typeName,
+		pkg:                     pkg,
+		fields:                  fields,
 		shouldDisableMarshalFns: shouldDisableMarshalFns,
 	}
 }

--- a/cli/pflags/api/templates.go
+++ b/cli/pflags/api/templates.go
@@ -28,6 +28,7 @@ import (
 	{{$name}} "{{$path}}"{{end}}
 )
 
+{{- if .ShouldDisableMarshalFns }}
 // If v is a pointer, it will get its element value or the zero value of the element type.
 // If v is not a pointer, it will return it as is.
 func ({{ .Name }}) elemValueOrNil(v interface{}) interface{} {
@@ -61,6 +62,7 @@ func ({{ .Name }}) mustMarshalJSON(v json.Marshaler) string {
 
     return string(raw)
 }
+{{- end }}
 
 // GetPFlagSet will return strongly types pflags for all fields in {{ .Name }} and its nested types. The format of the
 // flags is json-name.json-sub-name... etc.

--- a/cli/pflags/api/types.go
+++ b/cli/pflags/api/types.go
@@ -15,16 +15,16 @@ const (
 )
 
 type FieldInfo struct {
-	Name              string
-	GoName            string
-	Typ               types.Type
-	DefaultValue      string
-	UsageString       string
-	FlagMethodName    string
-	TestValue         string
-	TestStrategy      TestStrategy
-	ShouldBindDefault bool
-	ShouldTestDefault bool
+	Name                    string
+	GoName                  string
+	Typ                     types.Type
+	DefaultValue            string
+	UsageString             string
+	FlagMethodName          string
+	TestValue               string
+	TestStrategy            TestStrategy
+	ShouldBindDefault       bool
+	ShouldTestDefault       bool
 }
 
 // Holds the finalized information passed to the template for evaluation.
@@ -35,4 +35,5 @@ type TypeInfo struct {
 	Name      string
 	TypeRef   string
 	Imports   map[string]string
+	ShouldDisableMarshalFns bool
 }

--- a/cli/pflags/cmd/root.go
+++ b/cli/pflags/cmd/root.go
@@ -15,6 +15,7 @@ var (
 	pkg                       string
 	defaultValuesVariable     string
 	shouldBindDefaultVariable bool
+	shouldDisableMarshalFns bool
 )
 
 var root = cobra.Command{
@@ -35,6 +36,7 @@ func init() {
 	root.Flags().StringVarP(&pkg, "package", "p", ".", "Determines the source/destination package.")
 	root.Flags().StringVar(&defaultValuesVariable, "default-var", "defaultConfig", "Points to a variable to use to load default configs. If specified & found, it'll be used instead of the values specified in the tag.")
 	root.Flags().BoolVar(&shouldBindDefaultVariable, "bind-default-var", false, "The generated PFlags Set will bind fields to the default variable.")
+	root.Flags().BoolVar(&shouldDisableMarshalFns, "exclude-marshal-fns", false, "Disable generating of Marshal functions for generated pflags.")
 }
 
 func Execute() error {
@@ -48,7 +50,7 @@ func generatePflagsProvider(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.Background()
-	gen, err := api.NewGenerator(pkg, structName, defaultValuesVariable, shouldBindDefaultVariable)
+	gen, err := api.NewGenerator(pkg, structName, defaultValuesVariable, shouldBindDefaultVariable, shouldDisableMarshalFns)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Adding --exclude-marshal-fns to execlude the generation of following 3 functions which are not required in flytectl 

* func ({{ .Name }}) elemValueOrNil(v interface{}) interface{} 
* func ({{ .Name }}) mustJsonMarshal(v interface{}) string 
* func ({{ .Name }}) mustMarshalJSON(v json.Marshaler) string 

The default behavior is to generate these functions and hence keep backward compatibility.


eg usage in flytectl
```

//go:generate pflags Config --default-var DefaultConfig --bind-default-var --exclude-marshal-fns
```


generated file which mainly generates the GetPFlagSet

```
// Code generated by go generate; DO NOT EDIT.
// This file was generated by robots.

package project

import (
	"fmt"

	"github.com/spf13/pflag"
)

// GetPFlagSet will return strongly types pflags for all fields in Config and its nested types. The format of the
// flags is json-name.json-sub-name... etc.
func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "filter.fieldSelector"), DefaultConfig.Filter.FieldSelector, "Specifies the Field selector")
	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "filter.sortBy"), DefaultConfig.Filter.SortBy, "Specifies which field to sort results ")
	cmdFlags.Int32(fmt.Sprintf("%v%v", prefix, "filter.limit"), DefaultConfig.Filter.Limit, "Specifies the limit")
	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "filter.asc"), DefaultConfig.Filter.Asc, "Specifies the sorting order. By default flytectl sort result in descending order")
	return cmdFlags
}

```

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
