### PR TITLE
Added default no limit on storage 

### DIFF
--- a/storage/config.go
+++ b/storage/config.go
@@ -33,7 +33,7 @@ var (
 	defaultConfig = &Config{
 		Type: TypeS3,
 		Limits: LimitsConfig{
-			GetLimitMegabytes: 2,
+			GetLimitMegabytes: 0,
 		},
 		Connection: ConnectionConfig{
 			Region:   "us-east-1",

--- a/storage/config.go
+++ b/storage/config.go
@@ -33,7 +33,7 @@ var (
 	defaultConfig = &Config{
 		Type: TypeS3,
 		Limits: LimitsConfig{
-			GetLimitMegabytes: 0,
+			GetLimitMegabytes: 2,
 		},
 		Connection: ConnectionConfig{
 			Region:   "us-east-1",

--- a/storage/stow_store.go
+++ b/storage/stow_store.go
@@ -230,7 +230,7 @@ func (s *StowStore) ReadRaw(ctx context.Context, reference DataReference) (io.Re
 		return nil, err
 	}
 
-	if sizeMbs := sizeBytes / MiB; sizeMbs > GetConfig().Limits.GetLimitMegabytes {
+	if sizeMbs := sizeBytes / MiB; sizeMbs > GetConfig().Limits.GetLimitMegabytes && GetConfig().Limits.GetLimitMegabytes != 0 {
 		return nil, errors.Errorf(ErrExceedsLimit, "limit exceeded. %vmb > %vmb.", sizeMbs, GetConfig().Limits.GetLimitMegabytes)
 	}
 

--- a/storage/stow_store.go
+++ b/storage/stow_store.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/flyteorg/flytestdlib/errors"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	s32 "github.com/aws/aws-sdk-go/service/s3"
 	"github.com/graymeta/stow/azure"
@@ -19,8 +21,6 @@ import (
 	"github.com/flyteorg/flytestdlib/contextutils"
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils/labeled"
-
-	"github.com/flyteorg/flytestdlib/errors"
 
 	"github.com/flyteorg/flytestdlib/promutils"
 
@@ -230,8 +230,10 @@ func (s *StowStore) ReadRaw(ctx context.Context, reference DataReference) (io.Re
 		return nil, err
 	}
 
-	if sizeMbs := sizeBytes / MiB; sizeMbs > GetConfig().Limits.GetLimitMegabytes && GetConfig().Limits.GetLimitMegabytes != 0 {
-		return nil, errors.Errorf(ErrExceedsLimit, "limit exceeded. %vmb > %vmb.", sizeMbs, GetConfig().Limits.GetLimitMegabytes)
+	if GetConfig().Limits.GetLimitMegabytes != 0 {
+		if sizeMbs := sizeBytes / MiB; sizeMbs > GetConfig().Limits.GetLimitMegabytes {
+			return nil, errors.Errorf(ErrExceedsLimit, "limit exceeded. %vmb > %vmb.", sizeMbs, GetConfig().Limits.GetLimitMegabytes)
+		}
 	}
 
 	return item.Open()

--- a/storage/stow_store_test.go
+++ b/storage/stow_store_test.go
@@ -181,6 +181,8 @@ func TestStowStore_ReadRaw(t *testing.T) {
 	t.Run("Exceeds limit", func(t *testing.T) {
 		testScope := promutils.NewTestScope()
 		fn := fQNFn["s3"]
+		GetConfig().Limits.GetLimitMegabytes = 2
+
 		s, err := NewStowRawStore(fn(container), &mockStowLoc{
 			ContainerCb: func(id string) (stow.Container, error) {
 				if id == container {
@@ -205,6 +207,35 @@ func TestStowStore_ReadRaw(t *testing.T) {
 		assert.Error(t, err)
 		assert.True(t, IsExceedsLimit(err))
 		assert.NotNil(t, errors.Cause(err))
+	})
+
+	t.Run("No Limit", func(t *testing.T) {
+		testScope := promutils.NewTestScope()
+		fn := fQNFn["s3"]
+		GetConfig().Limits.GetLimitMegabytes = 0
+
+		s, err := NewStowRawStore(fn(container), &mockStowLoc{
+			ContainerCb: func(id string) (stow.Container, error) {
+				if id == container {
+					return newMockStowContainer(container), nil
+				}
+				return nil, fmt.Errorf("container is not supported")
+			},
+			CreateContainerCb: func(name string) (stow.Container, error) {
+				if name == container {
+					return newMockStowContainer(container), nil
+				}
+				return nil, fmt.Errorf("container is not supported")
+			},
+		}, false, testScope)
+		assert.NoError(t, err)
+		err = s.WriteRaw(context.TODO(), DataReference("s3://container/path"), 3*MiB, Options{}, bytes.NewReader([]byte{}))
+		assert.NoError(t, err)
+		metadata, err := s.Head(context.TODO(), DataReference("s3://container/path"))
+		assert.NoError(t, err)
+		assert.True(t, metadata.Exists())
+		_, err = s.ReadRaw(context.TODO(), DataReference("s3://container/path"))
+		assert.Nil(t, err)
 	})
 
 	t.Run("Happy Path multi-container enabled", func(t *testing.T) {

--- a/storage/stow_store_test.go
+++ b/storage/stow_store_test.go
@@ -181,7 +181,6 @@ func TestStowStore_ReadRaw(t *testing.T) {
 	t.Run("Exceeds limit", func(t *testing.T) {
 		testScope := promutils.NewTestScope()
 		fn := fQNFn["s3"]
-		GetConfig().Limits.GetLimitMegabytes = 2
 
 		s, err := NewStowRawStore(fn(container), &mockStowLoc{
 			ContainerCb: func(id string) (stow.Container, error) {


### PR DESCRIPTION
# TL;DR

Context :- A user started [discussion](https://github.com/flyteorg/flyte/discussions/1287) regarding a bug in copiliot.  where copiliot failes with large files because of stdlib limit check.  We don't want any limit on size in case of copiliot


- If GetLimitMegabytes is 0 then  don't check size limit 


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/1251
https://github.com/flyteorg/flyte/issues/1253
https://github.com/flyteorg/flyte/discussions/1287

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
