### PR TITLE
Support DeleteDelayed operation in AutoRefresh cache

### DIFF
--- a/cache/sync_set.go
+++ b/cache/sync_set.go
@@ -1,0 +1,40 @@
+package cache
+
+import "sync"
+
+var emptyVal = struct{}{}
+
+// syncSet is a thread-safe Set.
+type syncSet struct {
+	underlying sync.Map
+}
+
+// Contains checks if the key is present in the set.
+func (s *syncSet) Contains(key interface{}) bool {
+	_, found := s.underlying.Load(key)
+	return found
+}
+
+// Insert adds a new key to the set if it doesn't already exist.
+func (s *syncSet) Insert(key interface{}) {
+	s.underlying.Store(key, emptyVal)
+}
+
+// Remove deletes a key from the set.
+func (s *syncSet) Remove(key interface{}) {
+	s.underlying.Delete(key)
+}
+
+// Range allows iterating over the set. Deleting the key while iterating is a supported operation.
+func (s *syncSet) Range(callback func(key interface{}) bool) {
+	s.underlying.Range(func(key, value interface{}) bool {
+		return callback(key)
+	})
+}
+
+// newSyncSet initializes a new thread-safe set.
+func newSyncSet() *syncSet {
+	return &syncSet{
+		underlying: sync.Map{},
+	}
+}

--- a/cache/sync_set_test.go
+++ b/cache/sync_set_test.go
@@ -1,0 +1,49 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func rangeAndRemove(tb testing.TB, s *syncSet, count int) {
+	for i := 0; i < count; i++ {
+		s.Insert(i)
+	}
+
+	s.Range(func(key interface{}) bool {
+		s.Remove(key)
+		return true
+	})
+
+	for i := 0; i < count; i++ {
+		assert.False(tb, s.Contains(i))
+	}
+}
+
+func TestSyncSet_Range(t *testing.T) {
+	s := newSyncSet()
+	rangeAndRemove(t, s, 1000)
+}
+
+func BenchmarkSyncSet_Range(b *testing.B) {
+	s := newSyncSet()
+	rangeAndRemove(b, s, b.N)
+}
+
+func TestSyncSet_Contains(t *testing.T) {
+	s := newSyncSet()
+	count := 1000
+	for i := 0; i < count; i++ {
+		s.Insert(i)
+	}
+
+	for i := 0; i < count; i++ {
+		assert.True(t, s.Contains(i))
+		s.Remove(i)
+	}
+
+	for i := 0; i < count; i++ {
+		assert.False(t, s.Contains(i))
+	}
+}


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Support DeleteDelayed operation in AutoRefresh cache. This allows callers to safely enqueue a delete operation for a key and ensure it gets deleted even if the cache is in the middle of being refreshed.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue

https://github.com/flyteorg/flyte/issues/1379
