### PR TITLE
Go Generate and Add a Workflow to perform a sanity check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,3 +35,17 @@ jobs:
           GO111MODULE: "on"
         with:
           args: make install && make test_benchmark
+  test-generate-integrity:
+    name: Ensure go generate has run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - name: GoGenerate and Diff
+        uses: cedrickring/golang-action@1.6.0
+        env:
+          GO111MODULE: "on"
+        with:
+          args: go generate ./... && git diff --quiet || { echo "run go gonerate ./..."; exit 1; }

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,4 +48,4 @@ jobs:
         env:
           GO111MODULE: "on"
         with:
-          args: make mod_download && go generate ./... && git diff --quiet || { echo "run go gonerate ./..."; exit 1; }
+          args: make gen-config && git diff --quiet || { echo "run go gonerate ./..."; exit 1; }

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,4 +48,4 @@ jobs:
         env:
           GO111MODULE: "on"
         with:
-          args: go generate ./... && git diff --quiet || { echo "run go gonerate ./..."; exit 1; }
+          args: make mod_download && go generate ./... && git diff --quiet || { echo "run go gonerate ./..."; exit 1; }

--- a/cache/mocks/AutoRefresh.go
+++ b/cache/mocks/AutoRefresh.go
@@ -15,6 +15,38 @@ type AutoRefresh struct {
 	mock.Mock
 }
 
+type AutoRefresh_DeleteDelayed struct {
+	*mock.Call
+}
+
+func (_m AutoRefresh_DeleteDelayed) Return(_a0 error) *AutoRefresh_DeleteDelayed {
+	return &AutoRefresh_DeleteDelayed{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *AutoRefresh) OnDeleteDelayed(id string) *AutoRefresh_DeleteDelayed {
+	c := _m.On("DeleteDelayed", id)
+	return &AutoRefresh_DeleteDelayed{Call: c}
+}
+
+func (_m *AutoRefresh) OnDeleteDelayedMatch(matchers ...interface{}) *AutoRefresh_DeleteDelayed {
+	c := _m.On("DeleteDelayed", matchers...)
+	return &AutoRefresh_DeleteDelayed{Call: c}
+}
+
+// DeleteDelayed provides a mock function with given fields: id
+func (_m *AutoRefresh) DeleteDelayed(id string) error {
+	ret := _m.Called(id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type AutoRefresh_Get struct {
 	*mock.Call
 }

--- a/logger/config_flags.go
+++ b/logger/config_flags.go
@@ -28,6 +28,15 @@ func (Config) elemValueOrNil(v interface{}) interface{} {
 	return v
 }
 
+func (Config) mustJsonMarshal(v interface{}) string {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(raw)
+}
+
 func (Config) mustMarshalJSON(v json.Marshaler) string {
 	raw, err := v.MarshalJSON()
 	if err != nil {

--- a/logger/config_flags_test.go
+++ b/logger/config_flags_test.go
@@ -84,7 +84,7 @@ func testDecodeJson_Config(t *testing.T, val, result interface{}) {
 	assert.NoError(t, decode_Config(val, result))
 }
 
-func testDecodeSlice_Config(t *testing.T, vStringSlice, result interface{}) {
+func testDecodeRaw_Config(t *testing.T, vStringSlice, result interface{}) {
 	assert.NoError(t, decode_Config(vStringSlice, result))
 }
 
@@ -100,14 +100,6 @@ func TestConfig_SetFlags(t *testing.T) {
 	assert.True(t, cmdFlags.HasFlags())
 
 	t.Run("Test_show-source", func(t *testing.T) {
-		t.Run("DefaultValue", func(t *testing.T) {
-			// Test that default value is set properly
-			if vBool, err := cmdFlags.GetBool("show-source"); err == nil {
-				assert.Equal(t, bool(defaultConfig.IncludeSourceCode), vBool)
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := "1"
@@ -122,14 +114,6 @@ func TestConfig_SetFlags(t *testing.T) {
 		})
 	})
 	t.Run("Test_mute", func(t *testing.T) {
-		t.Run("DefaultValue", func(t *testing.T) {
-			// Test that default value is set properly
-			if vBool, err := cmdFlags.GetBool("mute"); err == nil {
-				assert.Equal(t, bool(defaultConfig.Mute), vBool)
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := "1"
@@ -144,14 +128,6 @@ func TestConfig_SetFlags(t *testing.T) {
 		})
 	})
 	t.Run("Test_level", func(t *testing.T) {
-		t.Run("DefaultValue", func(t *testing.T) {
-			// Test that default value is set properly
-			if vInt, err := cmdFlags.GetInt("level"); err == nil {
-				assert.Equal(t, int(defaultConfig.Level), vInt)
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := "1"
@@ -166,14 +142,6 @@ func TestConfig_SetFlags(t *testing.T) {
 		})
 	})
 	t.Run("Test_formatter.type", func(t *testing.T) {
-		t.Run("DefaultValue", func(t *testing.T) {
-			// Test that default value is set properly
-			if vString, err := cmdFlags.GetString("formatter.type"); err == nil {
-				assert.Equal(t, string(defaultConfig.Formatter.Type), vString)
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := "1"


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Missed running `go generate ./...` after updating the AutoRefresh cache interface. Added a github workflow to check for that for future changes.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue

https://github.com/flyteorg/flyte/issues/1379
