### PR TITLE
Print subsection in different heading level

### DIFF
--- a/config/config_cmd.go
+++ b/config/config_cmd.go
@@ -143,7 +143,7 @@ func printDocs(title string, isSubsection bool, section Section, visitedSection 
 				addSubsection(subVal.Interface(), subsections, fieldName, &fieldTypeString, tagType, visitedSection, visitedType)
 			}
 		}
-		printSection(fieldName, fieldTypeString, fieldDefaultValue, fieldDescription)
+		printSection(fieldName, fieldTypeString, fieldDefaultValue, fieldDescription, isSubsection)
 	}
 
 	if section != nil {
@@ -159,7 +159,7 @@ func printDocs(title string, isSubsection bool, section Section, visitedSection 
 			fieldDefaultValue := getDefaultValue(sections[sectionKey].GetConfig())
 
 			addSubsection(sections[sectionKey].GetConfig(), subsections, fieldName, &fieldTypeString, fieldType, visitedSection, visitedType)
-			printSection(fieldName, fieldTypeString, fieldDefaultValue, "")
+			printSection(fieldName, fieldTypeString, fieldDefaultValue, "", isSubsection)
 		}
 	}
 	orderedSectionKeys := sets.NewString()
@@ -182,7 +182,7 @@ func printToc(orderedSectionKeys sets.String) {
 func printTitle(title string, isSubsection bool) {
 	if isSubsection {
 		fmt.Println(title)
-		fmt.Println(strings.Repeat("-", 80))
+		fmt.Println(strings.Repeat("^", 80))
 	} else {
 		fmt.Println("Section:", title)
 		fmt.Println(strings.Repeat("=", 80))
@@ -190,8 +190,11 @@ func printTitle(title string, isSubsection bool) {
 	fmt.Println()
 }
 
-func printSection(name string, dataType string, defaultValue string, description string) {
+func printSection(name string, dataType string, defaultValue string, description string, isSubsection bool) {
 	c := "-"
+	if isSubsection {
+		c = "\""
+	}
 
 	fmt.Printf("%s ", name)
 	fmt.Printf("(%s)\n", dataType)
@@ -217,7 +220,6 @@ func addSubsection(val interface{}, subsections map[string]interface{}, fieldNam
 			// Add field name at the end to tell the difference between them.
 			*fieldTypeString = fmt.Sprintf("%s (%s)", *fieldTypeString, fieldName)
 			subsections[*fieldTypeString] = val
-
 		}
 	} else {
 		visitedSection[*fieldTypeString] = true


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>
# TL;DR
Print subsection in different heading level
Before:
![image](https://user-images.githubusercontent.com/37936015/141433434-c4b580eb-84da-4601-8137-d21be9477b70.png)
After:
![image](https://user-images.githubusercontent.com/37936015/141433634-73676354-7908-4c81-923a-e9cf5ebce849.png)

docs: https://flyte--1608.org.readthedocs.build/en/1608/deployment/cluster_config/flyteadmin_config.html#grpcauthorizationheader-string

rst heading format: https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html#headings

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
Related to https://github.com/flyteorg/flyte/pull/1608

## Follow-up issue
_NA_