### PR TITLE
Allow creation of bitset with 0 size

### DIFF
--- a/bitarray/bitset.go
+++ b/bitarray/bitset.go
@@ -1,6 +1,7 @@
 package bitarray
 
 import (
+	//"math"
 	"unsafe"
 )
 
@@ -67,7 +68,10 @@ func (s BitSet) DeepCopy() BitSet {
 
 // Initializes a new BitSet of the specified size.
 func NewBitSet(desiredCap uint) *BitSet {
-	// Create enough blocks to contain the number of intended bits.
-	a := make(BitSet, ((desiredCap-1)/blockSize)+1)
+	size := desiredCap / blockSize
+	if desiredCap % blockSize != 0 {
+		size++
+	}
+	a := make(BitSet, size)
 	return &a
 }


### PR DESCRIPTION
# TL;DR
Initializing an empty BitSet currently results in a panic. This is a result of the size computation when the desiredCap is 0.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2184

## Follow-up issue
_NA_
