### PR TITLE
#patch Fix azure stow storage prefix

### DIFF
--- a/storage/stow_store.go
+++ b/storage/stow_store.go
@@ -47,7 +47,7 @@ var fQNFn = map[string]func(string) DataReference{
 		return DataReference(fmt.Sprintf("sw://%s", bucket))
 	},
 	azure.Kind: func(bucket string) DataReference {
-		return DataReference(fmt.Sprintf("afs://%s", bucket))
+		return DataReference(fmt.Sprintf("abfs://%s", bucket))
 	},
 	local.Kind: func(bucket string) DataReference {
 		return DataReference(fmt.Sprintf("file://%s", bucket))

--- a/storage/stow_store_test.go
+++ b/storage/stow_store_test.go
@@ -16,8 +16,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	s32 "github.com/aws/aws-sdk-go/service/s3"
 
+	"github.com/flyteorg/stow/azure"
 	"github.com/flyteorg/stow/google"
 	"github.com/flyteorg/stow/local"
+	"github.com/flyteorg/stow/oracle"
+	"github.com/flyteorg/stow/s3"
+	"github.com/flyteorg/stow/swift"
 	"github.com/pkg/errors"
 
 	"github.com/flyteorg/stow"
@@ -647,4 +651,13 @@ func TestStowStore_WriteRaw(t *testing.T) {
 		err = s.WriteRaw(context.TODO(), DataReference("s3://container/path"), 0, Options{}, bytes.NewReader([]byte{}))
 		assert.EqualError(t, err, "Failed to write data [0b] to path [path].: foo")
 	})
+}
+
+func TestStowStore_fQNFn(t *testing.T) {
+	assert.Equal(t, DataReference("s3://bucket"), fQNFn[s3.Kind]("bucket"))
+	assert.Equal(t, DataReference("gs://bucket"), fQNFn[google.Kind]("bucket"))
+	assert.Equal(t, DataReference("os://bucket"), fQNFn[oracle.Kind]("bucket"))
+	assert.Equal(t, DataReference("sw://bucket"), fQNFn[swift.Kind]("bucket"))
+	assert.Equal(t, DataReference("abfs://bucket"), fQNFn[azure.Kind]("bucket"))
+	assert.Equal(t, DataReference("file://bucket"), fQNFn[local.Kind]("bucket"))
 }


### PR DESCRIPTION
# TL;DR
Use storage prefix `abfs://` instead of `afs://`, which is not supported by the azure fsspec plugin, see https://github.com/fsspec/adlfs/blob/bc6e7498af806fe851b4c0157612033b46c03176/README.md

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Use storage prefix `abfs://` instead of `afs://`, which is not supported by the azure fsspec plugin, see https://github.com/fsspec/adlfs/blob/bc6e7498af806fe851b4c0157612033b46c03176/README.md
