### PR TITLE
Append the labels that don't exist in metricStringKeys

### DIFF
--- a/promutils/labeled/counter_test.go
+++ b/promutils/labeled/counter_test.go
@@ -16,7 +16,9 @@ func TestLabeledCounter(t *testing.T) {
 	})
 
 	scope := promutils.NewTestScope()
-	c := NewCounter("lbl_counter", "help", scope)
+	// Make sure we will not register the same metrics key again.
+	option := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.DomainKey.String()}}
+	c := NewCounter("lbl_counter", "help", scope, option)
 	assert.NotNil(t, c)
 	ctx := context.TODO()
 	c.Inc(ctx)

--- a/promutils/labeled/gauge.go
+++ b/promutils/labeled/gauge.go
@@ -113,8 +113,9 @@ func NewGauge(name, description string, scope promutils.Scope, opts ...MetricOpt
 		if _, emitUnlabeledMetric := opt.(EmitUnlabeledMetricOption); emitUnlabeledMetric {
 			g.Gauge = scope.MustNewGauge(GetUnlabeledMetricName(name), description)
 		} else if additionalLabels, casted := opt.(AdditionalLabelsOption); casted {
-			g.GaugeVec = scope.MustNewGaugeVec(name, description, append(metricStringKeys, additionalLabels.Labels...)...)
-			g.additionalLabels = contextutils.MetricKeysFromStrings(additionalLabels.Labels)
+			labels := GetUniqueLabels(metricStringKeys, additionalLabels.Labels)
+			g.GaugeVec = scope.MustNewGaugeVec(name, description, append(metricStringKeys, labels...)...)
+			g.additionalLabels = contextutils.MetricKeysFromStrings(labels)
 		}
 	}
 

--- a/promutils/labeled/gauge_test.go
+++ b/promutils/labeled/gauge_test.go
@@ -20,7 +20,9 @@ func TestLabeledGauge(t *testing.T) {
 	scope := promutils.NewScope("testscope")
 	ctx := context.Background()
 	ctx = contextutils.WithProjectDomain(ctx, "flyte", "dev")
-	g := NewGauge("unittest", "some desc", scope)
+	// Make sure we will not register the same metrics key again.
+	option := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.DomainKey.String()}}
+	g := NewGauge("unittest", "some desc", scope, option)
 	assert.NotNil(t, g)
 
 	g.Inc(ctx)

--- a/promutils/labeled/stopwatch.go
+++ b/promutils/labeled/stopwatch.go
@@ -82,9 +82,10 @@ func NewStopWatch(name, description string, scale time.Duration, scope promutils
 		if _, emitUnableMetric := opt.(EmitUnlabeledMetricOption); emitUnableMetric {
 			sw.StopWatch = scope.MustNewStopWatch(GetUnlabeledMetricName(name), description, scale)
 		} else if additionalLabels, casted := opt.(AdditionalLabelsOption); casted {
+			labels := GetUniqueLabels(metricStringKeys, additionalLabels.Labels)
 			sw.StopWatchVec = scope.MustNewStopWatchVec(name, description, scale,
-				append(metricStringKeys, additionalLabels.Labels...)...)
-			sw.additionalLabels = contextutils.MetricKeysFromStrings(additionalLabels.Labels)
+				append(metricStringKeys, labels...)...)
+			sw.additionalLabels = contextutils.MetricKeysFromStrings(labels)
 		}
 	}
 

--- a/promutils/labeled/stopwatch_test.go
+++ b/promutils/labeled/stopwatch_test.go
@@ -18,7 +18,9 @@ func TestLabeledStopWatch(t *testing.T) {
 
 	t.Run("always labeled", func(t *testing.T) {
 		scope := promutils.NewTestScope()
-		c := NewStopWatch("lbl_counter", "help", time.Second, scope)
+		// Make sure we will not register the same metrics key again.
+		option := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.DomainKey.String()}}
+		c := NewStopWatch("lbl_counter", "help", time.Second, scope, option)
 		assert.NotNil(t, c)
 		ctx := context.TODO()
 		w := c.Start(ctx)

--- a/promutils/labeled/summary.go
+++ b/promutils/labeled/summary.go
@@ -43,8 +43,9 @@ func NewSummary(name, description string, scope promutils.Scope, opts ...MetricO
 		if _, emitUnlabeledMetric := opt.(EmitUnlabeledMetricOption); emitUnlabeledMetric {
 			s.Summary = scope.MustNewSummary(GetUnlabeledMetricName(name), description)
 		} else if additionalLabels, casted := opt.(AdditionalLabelsOption); casted {
-			s.SummaryVec = scope.MustNewSummaryVec(name, description, append(metricStringKeys, additionalLabels.Labels...)...)
-			s.additionalLabels = contextutils.MetricKeysFromStrings(additionalLabels.Labels)
+			labels := GetUniqueLabels(metricStringKeys, additionalLabels.Labels)
+			s.SummaryVec = scope.MustNewSummaryVec(name, description, append(metricStringKeys, labels...)...)
+			s.additionalLabels = contextutils.MetricKeysFromStrings(labels)
 		}
 	}
 

--- a/promutils/labeled/summary_test.go
+++ b/promutils/labeled/summary_test.go
@@ -21,7 +21,9 @@ func TestLabeledSummary(t *testing.T) {
 		scope := promutils.NewScope("testscope_summary")
 		ctx := context.Background()
 		ctx = contextutils.WithProjectDomain(ctx, "flyte", "dev")
-		s := NewSummary("unittest", "some desc", scope)
+		// Make sure we will not register the same metrics key again.
+		option := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.DomainKey.String()}}
+		s := NewSummary("unittest", "some desc", scope, option)
 		assert.NotNil(t, s)
 
 		s.Observe(ctx, 10)


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
We should append the labels that don't exist in metricStringKeys

Failed to start datacatalog in single binary because we attempted to register the same metric key.

Error message:
```
 Failed to register metrics. Error: descriptor Desc{fqName: \"datacatalog:datacatalog:storage:read_failure\", help: 
\"Indicates failure in GET for a given reference\", constLabels: {}, variableLabels: [app_name project domain exec_id wf 
node task tasktype runtime_type runtime_version failure_type failure_type]} is invalid: duplicate label names [goroutine 83 
[running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:24 
+0x65\ngithub.com/flyteorg/datacatalog/pkg/rpc/datacatalogservice.NewDataCatalogService.func
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2266


## Follow-up issue
_NA_
