### PR TITLE
Set default log level in config to 'warn'

### DIFF
--- a/database/config.go
+++ b/database/config.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/flyteorg/flytestdlib/config"
-	"gorm.io/gorm/logger"
 )
 
 const (
@@ -52,7 +51,6 @@ type DbConfig struct {
 	MaxIdleConnections                      int             `json:"maxIdleConnections" pflag:",maxIdleConnections sets the maximum number of connections in the idle connection pool."`
 	MaxOpenConnections                      int             `json:"maxOpenConnections" pflag:",maxOpenConnections sets the maximum number of open connections to the database."`
 	ConnMaxLifeTime                         config.Duration `json:"connMaxLifeTime" pflag:",sets the maximum amount of time a connection may be reused"`
-	LogLevel                                logger.LogLevel `json:"log_level" pflag:"-,"`
 	Postgres                                PostgresConfig  `json:"postgres,omitempty"`
 	SQLite                                  SQLiteConfig    `json:"sqlite,omitempty"`
 }

--- a/logger/config.go
+++ b/logger/config.go
@@ -27,7 +27,7 @@ var (
 		Formatter: FormatterConfig{
 			Type: FormatterJSON,
 		},
-		Level: InfoLevel,
+		Level: WarnLevel,
 	}
 
 	configSection = config.MustRegisterSectionWithUpdates(configSectionKey, defaultConfig, func(ctx context.Context, newValue config.Config) {

--- a/profutils/server_test.go
+++ b/profutils/server_test.go
@@ -73,7 +73,7 @@ func TestConfigHandler(t *testing.T) {
 		"logger": map[string]interface{}{
 			"show-source": false,
 			"mute":        false,
-			"level":       float64(4),
+			"level":       float64(3),
 			"formatter": map[string]interface{}{
 				"type": "json",
 			},


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
It's not really desirable to have a verbose log level as the default. We can configure that for flyte sandbox deployments as necessary.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2324

## Follow-up issue
_NA_
