### PR TITLE
Update gorm 'info' log level translation

### DIFF
--- a/database/gorm.go
+++ b/database/gorm.go
@@ -30,9 +30,9 @@ func GetGormLogger(ctx context.Context, logConfig *logger.Config) gormLogger.Int
 	case logger.ErrorLevel:
 		logLevel = gormLogger.Error
 	case logger.WarnLevel:
-		logLevel = gormLogger.Warn
-	case logger.InfoLevel:
 		fallthrough
+	case logger.InfoLevel:
+		logLevel = gormLogger.Warn
 	case logger.DebugLevel:
 		logLevel = gormLogger.Info
 		ignoreRecordNotFoundError = false


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
By default, setting the gorm log level to 'info' results in all sql being dumped to logs. This is pretty verbose, so this changes settting the gorm log level to 'info' only when the user config is set to 'debug'

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2324

## Follow-up issue
_NA_
