### PR TITLE
max open connection in database updated from 1000 to 100

### DIFF
--- a/database/config.go
+++ b/database/config.go
@@ -15,7 +15,7 @@ const (
 
 var defaultConfig = &DbConfig{
 	MaxIdleConnections: 10,
-	MaxOpenConnections: 1000,
+	MaxOpenConnections: 100,
 	ConnMaxLifeTime:    config.Duration{Duration: time.Hour},
 	Postgres: PostgresConfig{
 		Port:         5432,

--- a/database/config_test.go
+++ b/database/config_test.go
@@ -22,7 +22,7 @@ func TestParseDatabaseConfig(t *testing.T) {
 	assert.NoError(t, accessor.UpdateConfig(context.Background()))
 
 	assert.Equal(t, false, GetConfig().EnableForeignKeyConstraintWhenMigrating)
-	assert.Equal(t, 1000, GetConfig().MaxOpenConnections)
+	assert.Equal(t, 100, GetConfig().MaxOpenConnections)
 	assert.Equal(t, 10, GetConfig().MaxIdleConnections)
 	assert.Equal(t, config.Duration{Duration: 3600000000000}, GetConfig().ConnMaxLifeTime)
 


### PR DESCRIPTION

# TL;DR
- Decrease the number of max open connection to 100, 1000 is very high number for default

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/2171
## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
