### PR TITLE
Set unique labels string on prometheus metrics

### DIFF
--- a/promutils/labeled/counter_test.go
+++ b/promutils/labeled/counter_test.go
@@ -20,20 +20,20 @@ func TestLabeledCounter(t *testing.T) {
 	})
 
 	t.Run("Labeled", func(t *testing.T) {
-		scope := promutils.NewScope("testscope_summary")
+		scope := promutils.NewScope("testscope_counter")
 		c := NewCounter("c1", "some desc", scope)
 		assert.NotNil(t, c)
-		ctx := context.TODO()
-		c.Inc(ctx)
-		c.Add(ctx, 1.0)
 
+		ctx := context.TODO()
 		var header = `
-			# HELP testscope_summary:c1 some desc
-			# TYPE testscope_summary:c1 counter
+			# HELP testscope_counter:c1 some desc
+			# TYPE testscope_counter:c1 counter
 		`
 
+		c.Inc(ctx)
+		c.Add(ctx, 1.0)
 		var expected = `
-			testscope_summary:c1{domain="",project="",task="",wf=""} 2
+			testscope_counter:c1{domain="",project="",task="",wf=""} 2
 		`
 		err := testutil.CollectAndCompare(c.CounterVec, strings.NewReader(header+expected))
 		assert.NoError(t, err)
@@ -41,10 +41,9 @@ func TestLabeledCounter(t *testing.T) {
 		ctx = contextutils.WithProjectDomain(ctx, "project", "domain")
 		c.Inc(ctx)
 		c.Add(ctx, 1.0)
-
 		expected = `
-			testscope_summary:c1{domain="",project="",task="",wf=""} 2
-			testscope_summary:c1{domain="domain",project="project",task="",wf=""} 2
+			testscope_counter:c1{domain="",project="",task="",wf=""} 2
+			testscope_counter:c1{domain="domain",project="project",task="",wf=""} 2
 		`
 		err = testutil.CollectAndCompare(c.CounterVec, strings.NewReader(header+expected))
 		assert.NoError(t, err)
@@ -52,52 +51,51 @@ func TestLabeledCounter(t *testing.T) {
 		ctx = contextutils.WithTaskID(ctx, "task")
 		c.Inc(ctx)
 		c.Add(ctx, 1.0)
-
 		expected = `
-			testscope_summary:c1{domain="",project="",task="",wf=""} 2
-			testscope_summary:c1{domain="domain",project="project",task="",wf=""} 2
-			testscope_summary:c1{domain="domain",project="project",task="task",wf=""} 2
+			testscope_counter:c1{domain="",project="",task="",wf=""} 2
+			testscope_counter:c1{domain="domain",project="project",task="",wf=""} 2
+			testscope_counter:c1{domain="domain",project="project",task="task",wf=""} 2
 		`
 		err = testutil.CollectAndCompare(c.CounterVec, strings.NewReader(header+expected))
 		assert.NoError(t, err)
 	})
 
 	t.Run("Unlabeled", func(t *testing.T) {
-		scope := promutils.NewScope("testscope_summary")
+		scope := promutils.NewScope("testscope_counter")
 		c := NewCounter("c2", "some desc", scope, EmitUnlabeledMetricOption{})
 		assert.NotNil(t, c)
-		ctx := context.TODO()
-		c.Inc(ctx)
-		c.Add(ctx, 1.0)
 
+		ctx := context.TODO()
 		var header = `
-			# HELP testscope_summary:c2_unlabeled some desc
-			# TYPE testscope_summary:c2_unlabeled counter
+			# HELP testscope_counter:c2_unlabeled some desc
+			# TYPE testscope_counter:c2_unlabeled counter
 		`
 
+		c.Inc(ctx)
+		c.Add(ctx, 1.0)
 		var expected = `
-			testscope_summary:c2_unlabeled 2
+			testscope_counter:c2_unlabeled 2
 		`
 		err := testutil.CollectAndCompare(c.Counter, strings.NewReader(header+expected))
 		assert.NoError(t, err)
 	})
 
 	t.Run("AdditionalLabels", func(t *testing.T) {
-		scope := promutils.NewScope("testscope_summary")
+		scope := promutils.NewScope("testscope_counter")
 		opts := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.ExecIDKey.String()}}
 		c := NewCounter("c3", "some desc", scope, opts)
 		assert.NotNil(t, c)
-		ctx := context.TODO()
-		c.Inc(ctx)
-		c.Add(ctx, 1.0)
 
+		ctx := context.TODO()
 		var header = `
-			# HELP testscope_summary:c3 some desc
-			# TYPE testscope_summary:c3 counter
+			# HELP testscope_counter:c3 some desc
+			# TYPE testscope_counter:c3 counter
 		`
 
+		c.Inc(ctx)
+		c.Add(ctx, 1.0)
 		var expected = `
-			testscope_summary:c3{domain="",exec_id="",project="",task="",wf=""} 2
+			testscope_counter:c3{domain="",exec_id="",project="",task="",wf=""} 2
 		`
 		err := testutil.CollectAndCompare(c.CounterVec, strings.NewReader(header+expected))
 		assert.NoError(t, err)
@@ -105,10 +103,9 @@ func TestLabeledCounter(t *testing.T) {
 		ctx = contextutils.WithExecutionID(ctx, "exec_id")
 		c.Inc(ctx)
 		c.Add(ctx, 1.0)
-
 		expected = `
-			testscope_summary:c3{domain="",exec_id="",project="",task="",wf=""} 2
-			testscope_summary:c3{domain="",exec_id="exec_id",project="",task="",wf=""} 2
+			testscope_counter:c3{domain="",exec_id="",project="",task="",wf=""} 2
+			testscope_counter:c3{domain="",exec_id="exec_id",project="",task="",wf=""} 2
 		`
 		err = testutil.CollectAndCompare(c.CounterVec, strings.NewReader(header+expected))
 		assert.NoError(t, err)

--- a/promutils/labeled/counter_test.go
+++ b/promutils/labeled/counter_test.go
@@ -2,37 +2,115 @@ package labeled
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/flyteorg/flytestdlib/contextutils"
 	"github.com/flyteorg/flytestdlib/promutils"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLabeledCounter(t *testing.T) {
 	UnsetMetricKeys()
 	assert.NotPanics(t, func() {
-		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey, contextutils.LaunchPlanIDKey)
+		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey)
 	})
 
-	scope := promutils.NewTestScope()
-	// Make sure we will not register the same metrics key again.
-	option := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.DomainKey.String()}}
-	c := NewCounter("lbl_counter", "help", scope, option)
-	assert.NotNil(t, c)
-	ctx := context.TODO()
-	c.Inc(ctx)
-	c.Add(ctx, 1.0)
+	t.Run("Labeled", func(t *testing.T) {
+		scope := promutils.NewScope("testscope_summary")
+		c := NewCounter("c1", "some desc", scope)
+		assert.NotNil(t, c)
+		ctx := context.TODO()
+		c.Inc(ctx)
+		c.Add(ctx, 1.0)
 
-	ctx = contextutils.WithProjectDomain(ctx, "project", "domain")
-	c.Inc(ctx)
-	c.Add(ctx, 1.0)
+		var header = `
+			# HELP testscope_summary:c1 some desc
+			# TYPE testscope_summary:c1 counter
+		`
 
-	ctx = contextutils.WithTaskID(ctx, "task")
-	c.Inc(ctx)
-	c.Add(ctx, 1.0)
+		var expected = `
+			testscope_summary:c1{domain="",project="",task="",wf=""} 2
+		`
+		err := testutil.CollectAndCompare(c.CounterVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
 
-	ctx = contextutils.WithLaunchPlanID(ctx, "lp")
-	c.Inc(ctx)
-	c.Add(ctx, 1.0)
+		ctx = contextutils.WithProjectDomain(ctx, "project", "domain")
+		c.Inc(ctx)
+		c.Add(ctx, 1.0)
+
+		expected = `
+			testscope_summary:c1{domain="",project="",task="",wf=""} 2
+			testscope_summary:c1{domain="domain",project="project",task="",wf=""} 2
+		`
+		err = testutil.CollectAndCompare(c.CounterVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+
+		ctx = contextutils.WithTaskID(ctx, "task")
+		c.Inc(ctx)
+		c.Add(ctx, 1.0)
+
+		expected = `
+			testscope_summary:c1{domain="",project="",task="",wf=""} 2
+			testscope_summary:c1{domain="domain",project="project",task="",wf=""} 2
+			testscope_summary:c1{domain="domain",project="project",task="task",wf=""} 2
+		`
+		err = testutil.CollectAndCompare(c.CounterVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Unlabeled", func(t *testing.T) {
+		scope := promutils.NewScope("testscope_summary")
+		c := NewCounter("c2", "some desc", scope, EmitUnlabeledMetricOption{})
+		assert.NotNil(t, c)
+		ctx := context.TODO()
+		c.Inc(ctx)
+		c.Add(ctx, 1.0)
+
+		var header = `
+			# HELP testscope_summary:c2_unlabeled some desc
+			# TYPE testscope_summary:c2_unlabeled counter
+		`
+
+		var expected = `
+			testscope_summary:c2_unlabeled 2
+		`
+		err := testutil.CollectAndCompare(c.Counter, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+	})
+
+	t.Run("AdditionalLabels", func(t *testing.T) {
+		scope := promutils.NewScope("testscope_summary")
+		opts := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.ExecIDKey.String()}}
+		c := NewCounter("c3", "some desc", scope, opts)
+		assert.NotNil(t, c)
+		ctx := context.TODO()
+		c.Inc(ctx)
+		c.Add(ctx, 1.0)
+
+		var header = `
+			# HELP testscope_summary:c3 some desc
+			# TYPE testscope_summary:c3 counter
+		`
+
+		var expected = `
+			testscope_summary:c3{domain="",exec_id="",project="",task="",wf=""} 2
+		`
+		err := testutil.CollectAndCompare(c.CounterVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+
+		ctx = contextutils.WithExecutionID(ctx, "exec_id")
+		c.Inc(ctx)
+		c.Add(ctx, 1.0)
+
+		expected = `
+			testscope_summary:c3{domain="",exec_id="",project="",task="",wf=""} 2
+			testscope_summary:c3{domain="",exec_id="exec_id",project="",task="",wf=""} 2
+		`
+		err = testutil.CollectAndCompare(c.CounterVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+	})
 }

--- a/promutils/labeled/counter_test.go
+++ b/promutils/labeled/counter_test.go
@@ -62,7 +62,7 @@ func TestLabeledCounter(t *testing.T) {
 
 	t.Run("Unlabeled", func(t *testing.T) {
 		scope := promutils.NewScope("testscope_counter")
-		c := NewCounter("c2", "some desc", scope, EmitUnlabeledMetricOption{})
+		c := NewCounter("c2", "some desc", scope, EmitUnlabeledMetric)
 		assert.NotNil(t, c)
 
 		ctx := context.TODO()

--- a/promutils/labeled/gauge_test.go
+++ b/promutils/labeled/gauge_test.go
@@ -75,7 +75,7 @@ func TestLabeledGauge(t *testing.T) {
 
 	t.Run("Unlabeled", func(t *testing.T) {
 		scope := promutils.NewScope("testscope_gauge")
-		g := NewGauge("g2", "some desc", scope, EmitUnlabeledMetricOption{})
+		g := NewGauge("g2", "some desc", scope, EmitUnlabeledMetric)
 		assert.NotNil(t, g)
 
 		ctx := context.TODO()

--- a/promutils/labeled/gauge_test.go
+++ b/promutils/labeled/gauge_test.go
@@ -7,122 +7,124 @@ import (
 
 	"github.com/flyteorg/flytestdlib/contextutils"
 	"github.com/flyteorg/flytestdlib/promutils"
+
 	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLabeledGauge(t *testing.T) {
 	UnsetMetricKeys()
 	assert.NotPanics(t, func() {
-		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey, contextutils.LaunchPlanIDKey)
+		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey)
 	})
 
-	scope := promutils.NewScope("testscope")
-	ctx := context.Background()
-	ctx = contextutils.WithProjectDomain(ctx, "flyte", "dev")
-	// Make sure we will not register the same metrics key again.
-	option := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.DomainKey.String()}}
-	g := NewGauge("unittest", "some desc", scope, option)
-	assert.NotNil(t, g)
+	t.Run("Labeled", func(t *testing.T) {
+		scope := promutils.NewScope("testscope_gauge")
+		g := NewGauge("g1", "some desc", scope)
+		assert.NotNil(t, g)
 
-	g.Inc(ctx)
+		ctx := context.TODO()
+		const header = `
+			# HELP testscope_gauge:g1 some desc
+			# TYPE testscope_gauge:g1 gauge
+		`
 
-	const header = `
-		# HELP testscope:unittest some desc
-        # TYPE testscope:unittest gauge
-	`
-	var expected = `
-        testscope:unittest{domain="dev",lp="",project="flyte",task="",wf=""} 1
-	`
-	err := testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
-	assert.NoError(t, err)
+		g.Inc(ctx)
+		var expected = `
+			testscope_gauge:g1{domain="",project="",task="",wf=""} 1
+		`
+		err := testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
 
-	g.Set(ctx, 42)
-	expected = `
-        testscope:unittest{domain="dev",lp="",project="flyte",task="",wf=""} 42
-	`
-	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
-	assert.NoError(t, err)
+		g.Dec(ctx)
+		expected = `
+			testscope_gauge:g1{domain="",project="",task="",wf=""} 0
+		`
+		err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
 
-	g.Add(ctx, 1)
-	expected = `
-        testscope:unittest{domain="dev",lp="",project="flyte",task="",wf=""} 43
-	`
-	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
-	assert.NoError(t, err)
+		ctx = contextutils.WithProjectDomain(ctx, "project", "domain")
+		g.Set(ctx, 42)
+		expected = `
+			testscope_gauge:g1{domain="",project="",task="",wf=""} 0
+			testscope_gauge:g1{domain="domain",project="project",task="",wf=""} 42
+		`
+		err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
 
-	g.Dec(ctx)
-	expected = `
-        testscope:unittest{domain="dev",lp="",project="flyte",task="",wf=""} 42
-	`
-	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
-	assert.NoError(t, err)
+		ctx = contextutils.WithTaskID(ctx, "task")
+		g.Add(ctx, 1)
+		expected = `
+			testscope_gauge:g1{domain="",project="",task="",wf=""} 0
+			testscope_gauge:g1{domain="domain",project="project",task="",wf=""} 42
+			testscope_gauge:g1{domain="domain",project="project",task="task",wf=""} 1
+		`
+		err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
 
-	g.Sub(ctx, 1)
-	expected = `
-        testscope:unittest{domain="dev",lp="",project="flyte",task="",wf=""} 41
-	`
-	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
-	assert.NoError(t, err)
-
-	g.SetToCurrentTime(ctx)
-}
-
-func TestWithAdditionalLabels(t *testing.T) {
-	UnsetMetricKeys()
-	assert.NotPanics(t, func() {
-		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey, contextutils.LaunchPlanIDKey)
+		g.Sub(ctx, 1)
+		expected = `
+			testscope_gauge:g1{domain="",project="",task="",wf=""} 0
+			testscope_gauge:g1{domain="domain",project="project",task="",wf=""} 42
+			testscope_gauge:g1{domain="domain",project="project",task="task",wf=""} 0
+		`
+		err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
 	})
 
-	scope := promutils.NewScope("testscope")
-	ctx := context.Background()
-	ctx = contextutils.WithProjectDomain(ctx, "flyte", "dev")
-	g := NewGauge("unittestlabeled", "some desc", scope, AdditionalLabelsOption{Labels: []string{"bearing"}})
-	assert.NotNil(t, g)
+	t.Run("Unlabeled", func(t *testing.T) {
+		scope := promutils.NewScope("testscope_gauge")
+		g := NewGauge("g2", "some desc", scope, EmitUnlabeledMetricOption{})
+		assert.NotNil(t, g)
 
-	const header = `
-		# HELP testscope:unittestlabeled some desc
-		# TYPE testscope:unittestlabeled gauge
-	`
+		ctx := context.TODO()
+		const header = `
+			# HELP testscope_gauge:g2_unlabeled some desc
+			# TYPE testscope_gauge:g2_unlabeled gauge
+		`
 
-	g.Inc(ctx)
-	var expected = `
-        testscope:unittestlabeled{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-	`
-	err := testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
-	assert.NoError(t, err)
+		g.Inc(ctx)
+		var expected = `
+			testscope_gauge:g2_unlabeled 1
+		`
+		err := testutil.CollectAndCompare(g.Gauge, strings.NewReader(header+expected))
+		assert.NoError(t, err)
 
-	bearingKey := contextutils.Key("bearing")
-	ctx = context.WithValue(ctx, bearingKey, "123")
-	g.Set(ctx, 42)
-	expected = `
-		testscope:unittestlabeled{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-		testscope:unittestlabeled{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 42
-	`
-	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
-	assert.NoError(t, err)
+		g.Dec(ctx)
+		expected = `
+			testscope_gauge:g2_unlabeled 0
+		`
+		err = testutil.CollectAndCompare(g.Gauge, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+	})
 
-	g.Add(ctx, 1)
-	expected = `
-		testscope:unittestlabeled{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-		testscope:unittestlabeled{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 43
-	`
-	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
-	assert.NoError(t, err)
+	t.Run("AdditionalLabels", func(t *testing.T) {
+		scope := promutils.NewScope("testscope_gauge")
+		opts := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.ExecIDKey.String()}}
+		g := NewGauge("g3", "some desc", scope, opts)
+		assert.NotNil(t, g)
 
-	g.Dec(ctx)
-	expected = `
-		testscope:unittestlabeled{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-		testscope:unittestlabeled{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 42
-	`
-	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
-	assert.NoError(t, err)
+		ctx := context.TODO()
+		const header = `
+			# HELP testscope_gauge:g3 some desc
+			# TYPE testscope_gauge:g3 gauge
+		`
 
-	g.Sub(ctx, 42)
-	expected = `
-		testscope:unittestlabeled{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-		testscope:unittestlabeled{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 0
-	`
-	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
-	assert.NoError(t, err)
+		g.Inc(ctx)
+		var expected = `
+			testscope_gauge:g3{domain="",exec_id="",project="",task="",wf=""} 1
+		`
+		err := testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+
+		ctx = contextutils.WithExecutionID(ctx, "exec_id")
+		g.Inc(ctx)
+		expected = `
+			testscope_gauge:g3{domain="",exec_id="",project="",task="",wf=""} 1
+			testscope_gauge:g3{domain="",exec_id="exec_id",project="",task="",wf=""} 1
+		`
+		err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+	})
 }

--- a/promutils/labeled/stopwatch_test.go
+++ b/promutils/labeled/stopwatch_test.go
@@ -113,10 +113,10 @@ func TestLabeledStopWatch(t *testing.T) {
 		// promutils.StopWatch does not implement prometheus.Collector
 		/*var expected = `
 			testscope_stopwatch:s2_m{quantile="0.5"} 0
-            testscope_stopwatch:s2_m{quantile="0.9"} 0
-            testscope_stopwatch:s2_m{quantile="0.99"} 0
-            testscope_stopwatch:s2_m_sum 0
-            testscope_stopwatch:s2_m_count 1
+			testscope_stopwatch:s2_m{quantile="0.9"} 0
+			testscope_stopwatch:s2_m{quantile="0.99"} 0
+			testscope_stopwatch:s2_m_sum 0
+			testscope_stopwatch:s2_m_count 1
 		`
 		err := testutil.CollectAndCompare(s.StopWatch, strings.NewReader(header+expected))
 		assert.NoError(t, err)*/

--- a/promutils/labeled/stopwatch_test.go
+++ b/promutils/labeled/stopwatch_test.go
@@ -99,7 +99,7 @@ func TestLabeledStopWatch(t *testing.T) {
 
 	t.Run("Unlabeled", func(t *testing.T) {
 		scope := promutils.NewScope("testscope_stopwatch")
-		s := NewStopWatch("s2", "some desc", time.Minute, scope, EmitUnlabeledMetricOption{})
+		s := NewStopWatch("s2", "some desc", time.Minute, scope, EmitUnlabeledMetric)
 		assert.NotNil(t, s)
 
 		ctx := context.TODO()

--- a/promutils/labeled/stopwatch_test.go
+++ b/promutils/labeled/stopwatch_test.go
@@ -103,10 +103,10 @@ func TestLabeledStopWatch(t *testing.T) {
 		assert.NotNil(t, s)
 
 		ctx := context.TODO()
-		const header = `
+		/*const header = `
 			# HELP testscope_stopwatch:s2_m some desc
 			# TYPE testscope_stopwatch:s2_m summary
-		`
+		`*/
 
 		w := s.Start(ctx)
 		w.Stop()

--- a/promutils/labeled/stopwatch_test.go
+++ b/promutils/labeled/stopwatch_test.go
@@ -2,11 +2,15 @@ package labeled
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/flyteorg/flytestdlib/contextutils"
 	"github.com/flyteorg/flytestdlib/promutils"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,35 +20,171 @@ func TestLabeledStopWatch(t *testing.T) {
 		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey)
 	})
 
-	t.Run("always labeled", func(t *testing.T) {
-		scope := promutils.NewTestScope()
-		// Make sure we will not register the same metrics key again.
-		option := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.DomainKey.String()}}
-		c := NewStopWatch("lbl_counter", "help", time.Second, scope, option)
-		assert.NotNil(t, c)
+	t.Run("Labeled", func(t *testing.T) {
+		scope := promutils.NewScope("testscope_stopwatch")
+		s := NewStopWatch("s1", "some desc", time.Minute, scope)
+		assert.NotNil(t, s)
+
 		ctx := context.TODO()
-		w := c.Start(ctx)
+		const header = `
+			# HELP testscope_stopwatch:s1_m some desc
+			# TYPE testscope_stopwatch:s1_m summary
+		`
+
+		w := s.Start(ctx)
 		w.Stop()
+		var expected = `
+			testscope_stopwatch:s1_m{domain="",project="",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s1_m{domain="",project="",task="",wf="",quantile="0.9"} 0
+            testscope_stopwatch:s1_m{domain="",project="",task="",wf="",quantile="0.99"} 0
+            testscope_stopwatch:s1_m_sum{domain="",project="",task="",wf=""} 0
+            testscope_stopwatch:s1_m_count{domain="",project="",task="",wf=""} 1
+		`
+		err := testutil.CollectAndCompare(s.StopWatchVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
 
 		ctx = contextutils.WithProjectDomain(ctx, "project", "domain")
-		w = c.Start(ctx)
+		w = s.Start(ctx)
 		w.Stop()
+		expected = `
+			testscope_stopwatch:s1_m{domain="",project="",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s1_m{domain="",project="",task="",wf="",quantile="0.9"} 0
+            testscope_stopwatch:s1_m{domain="",project="",task="",wf="",quantile="0.99"} 0
+            testscope_stopwatch:s1_m_sum{domain="",project="",task="",wf=""} 0
+            testscope_stopwatch:s1_m_count{domain="",project="",task="",wf=""} 1
+			testscope_stopwatch:s1_m{domain="domain",project="project",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s1_m{domain="domain",project="project",task="",wf="",quantile="0.9"} 0
+            testscope_stopwatch:s1_m{domain="domain",project="project",task="",wf="",quantile="0.99"} 0
+            testscope_stopwatch:s1_m_sum{domain="domain",project="project",task="",wf=""} 0
+            testscope_stopwatch:s1_m_count{domain="domain",project="project",task="",wf=""} 1
+		`
+		err = testutil.CollectAndCompare(s.StopWatchVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
 
-		ctx = contextutils.WithTaskID(ctx, "task")
-		w = c.Start(ctx)
-		w.Stop()
+		now := time.Now()
+		s.Observe(ctx, now, now.Add(time.Minute))
+		expected = `
+			testscope_stopwatch:s1_m{domain="",project="",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s1_m{domain="",project="",task="",wf="",quantile="0.9"} 0
+            testscope_stopwatch:s1_m{domain="",project="",task="",wf="",quantile="0.99"} 0
+            testscope_stopwatch:s1_m_sum{domain="",project="",task="",wf=""} 0
+            testscope_stopwatch:s1_m_count{domain="",project="",task="",wf=""} 1
+			testscope_stopwatch:s1_m{domain="domain",project="project",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s1_m{domain="domain",project="project",task="",wf="",quantile="0.9"} 1
+            testscope_stopwatch:s1_m{domain="domain",project="project",task="",wf="",quantile="0.99"} 1
+            testscope_stopwatch:s1_m_sum{domain="domain",project="project",task="",wf=""} 1
+            testscope_stopwatch:s1_m_count{domain="domain",project="project",task="",wf=""} 2
+		`
+		err = testutil.CollectAndCompare(s.StopWatchVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
 
-		c.Observe(ctx, time.Now(), time.Now().Add(time.Second))
-		c.Time(ctx, func() {
+		s.Time(ctx, func() {
 			// Do nothing
 		})
+		expected = `
+			testscope_stopwatch:s1_m{domain="",project="",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s1_m{domain="",project="",task="",wf="",quantile="0.9"} 0
+            testscope_stopwatch:s1_m{domain="",project="",task="",wf="",quantile="0.99"} 0
+            testscope_stopwatch:s1_m_sum{domain="",project="",task="",wf=""} 0
+            testscope_stopwatch:s1_m_count{domain="",project="",task="",wf=""} 1
+			testscope_stopwatch:s1_m{domain="domain",project="project",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s1_m{domain="domain",project="project",task="",wf="",quantile="0.9"} 1
+            testscope_stopwatch:s1_m{domain="domain",project="project",task="",wf="",quantile="0.99"} 1
+            testscope_stopwatch:s1_m_sum{domain="domain",project="project",task="",wf=""} 1
+            testscope_stopwatch:s1_m_count{domain="domain",project="project",task="",wf=""} 3
+		`
+		err = testutil.CollectAndCompare(s.StopWatchVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
 	})
 
-	t.Run("unlabeled", func(t *testing.T) {
-		scope := promutils.NewTestScope()
-		c := NewStopWatch("lbl_counter_2", "help", time.Second, scope, EmitUnlabeledMetric)
-		assert.NotNil(t, c)
+	t.Run("Unlabeled", func(t *testing.T) {
+		scope := promutils.NewScope("testscope_stopwatch")
+		s := NewStopWatch("s2", "some desc", time.Minute, scope, EmitUnlabeledMetricOption{})
+		assert.NotNil(t, s)
 
-		c.Start(context.TODO())
+		ctx := context.TODO()
+		const header = `
+			# HELP testscope_stopwatch:s2_m some desc
+			# TYPE testscope_stopwatch:s2_m summary
+		`
+
+		w := s.Start(ctx)
+		w.Stop()
+		// promutils.StopWatch does not implement prometheus.Collector
+		/*var expected = `
+			testscope_stopwatch:s2_m{quantile="0.5"} 0
+            testscope_stopwatch:s2_m{quantile="0.9"} 0
+            testscope_stopwatch:s2_m{quantile="0.99"} 0
+            testscope_stopwatch:s2_m_sum 0
+            testscope_stopwatch:s2_m_count 1
+		`
+		err := testutil.CollectAndCompare(s.StopWatch, strings.NewReader(header+expected))
+		assert.NoError(t, err)*/
+	})
+
+	t.Run("AdditionalLabels", func(t *testing.T) {
+		scope := promutils.NewScope("testscope_stopwatch")
+		opts := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.ExecIDKey.String()}}
+		s := NewStopWatch("s3", "some desc", time.Minute, scope, opts)
+		assert.NotNil(t, s)
+
+		ctx := context.TODO()
+		const header = `
+			# HELP testscope_stopwatch:s3_m some desc
+			# TYPE testscope_stopwatch:s3_m summary
+		`
+
+		w := s.Start(ctx)
+		w.Stop()
+		var expected = `
+			testscope_stopwatch:s3_m{domain="",exec_id="",project="",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s3_m{domain="",exec_id="",project="",task="",wf="",quantile="0.9"} 0
+            testscope_stopwatch:s3_m{domain="",exec_id="",project="",task="",wf="",quantile="0.99"} 0
+            testscope_stopwatch:s3_m_sum{domain="",exec_id="",project="",task="",wf=""} 0
+            testscope_stopwatch:s3_m_count{domain="",exec_id="",project="",task="",wf=""} 1
+		`
+		err := testutil.CollectAndCompare(s.StopWatchVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+
+		ctx = contextutils.WithProjectDomain(ctx, "project", "domain")
+		w = s.Start(ctx)
+		w.Stop()
+		expected = `
+			testscope_stopwatch:s3_m{domain="",exec_id="",project="",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s3_m{domain="",exec_id="",project="",task="",wf="",quantile="0.9"} 0
+            testscope_stopwatch:s3_m{domain="",exec_id="",project="",task="",wf="",quantile="0.99"} 0
+            testscope_stopwatch:s3_m_sum{domain="",exec_id="",project="",task="",wf=""} 0
+            testscope_stopwatch:s3_m_count{domain="",exec_id="",project="",task="",wf=""} 1
+			testscope_stopwatch:s3_m{domain="domain",exec_id="",project="project",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s3_m{domain="domain",exec_id="",project="project",task="",wf="",quantile="0.9"} 0
+            testscope_stopwatch:s3_m{domain="domain",exec_id="",project="project",task="",wf="",quantile="0.99"} 0
+            testscope_stopwatch:s3_m_sum{domain="domain",exec_id="",project="project",task="",wf=""} 0
+            testscope_stopwatch:s3_m_count{domain="domain",exec_id="",project="project",task="",wf=""} 1
+		`
+		err = testutil.CollectAndCompare(s.StopWatchVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+
+		ctx = contextutils.WithExecutionID(ctx, "exec_id")
+		w = s.Start(ctx)
+		w.Stop()
+		expected = `
+			testscope_stopwatch:s3_m{domain="",exec_id="",project="",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s3_m{domain="",exec_id="",project="",task="",wf="",quantile="0.9"} 0
+            testscope_stopwatch:s3_m{domain="",exec_id="",project="",task="",wf="",quantile="0.99"} 0
+            testscope_stopwatch:s3_m_sum{domain="",exec_id="",project="",task="",wf=""} 0
+            testscope_stopwatch:s3_m_count{domain="",exec_id="",project="",task="",wf=""} 1
+			testscope_stopwatch:s3_m{domain="domain",exec_id="",project="project",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s3_m{domain="domain",exec_id="",project="project",task="",wf="",quantile="0.9"} 0
+            testscope_stopwatch:s3_m{domain="domain",exec_id="",project="project",task="",wf="",quantile="0.99"} 0
+            testscope_stopwatch:s3_m_sum{domain="domain",exec_id="",project="project",task="",wf=""} 0
+            testscope_stopwatch:s3_m_count{domain="domain",exec_id="",project="project",task="",wf=""} 1
+			testscope_stopwatch:s3_m{domain="domain",exec_id="exec_id",project="project",task="",wf="",quantile="0.5"} 0
+            testscope_stopwatch:s3_m{domain="domain",exec_id="exec_id",project="project",task="",wf="",quantile="0.9"} 0
+            testscope_stopwatch:s3_m{domain="domain",exec_id="exec_id",project="project",task="",wf="",quantile="0.99"} 0
+            testscope_stopwatch:s3_m_sum{domain="domain",exec_id="exec_id",project="project",task="",wf=""} 0
+            testscope_stopwatch:s3_m_count{domain="domain",exec_id="exec_id",project="project",task="",wf=""} 1
+		`
+		err = testutil.CollectAndCompare(s.StopWatchVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
 	})
 }

--- a/promutils/labeled/summary_test.go
+++ b/promutils/labeled/summary_test.go
@@ -7,76 +7,97 @@ import (
 
 	"github.com/flyteorg/flytestdlib/contextutils"
 	"github.com/flyteorg/flytestdlib/promutils"
+
 	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLabeledSummary(t *testing.T) {
 	UnsetMetricKeys()
 	assert.NotPanics(t, func() {
-		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey, contextutils.LaunchPlanIDKey)
+		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey)
 	})
 
-	t.Run("labeled", func(t *testing.T) {
+	t.Run("Labeled", func(t *testing.T) {
 		scope := promutils.NewScope("testscope_summary")
-		ctx := context.Background()
-		ctx = contextutils.WithProjectDomain(ctx, "flyte", "dev")
-		// Make sure we will not register the same metrics key again.
-		option := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.DomainKey.String()}}
-		s := NewSummary("unittest", "some desc", scope, option)
+		s := NewSummary("s1", "some desc", scope)
 		assert.NotNil(t, s)
 
-		s.Observe(ctx, 10)
-
+		ctx := context.TODO()
 		const header = `
-			# HELP testscope_summary:unittest some desc
-			# TYPE testscope_summary:unittest summary
+			# HELP testscope_summary:s1 some desc
+			# TYPE testscope_summary:s1 summary
 		`
+
+		s.Observe(ctx, 10)
 		var expected = `
-			testscope_summary:unittest{domain="dev",lp="",project="flyte",task="",wf="",quantile="0.5"} 10
-			testscope_summary:unittest{domain="dev",lp="",project="flyte",task="",wf="",quantile="0.9"} 10
-			testscope_summary:unittest{domain="dev",lp="",project="flyte",task="",wf="",quantile="0.99"} 10
-			testscope_summary:unittest_sum{domain="dev",lp="",project="flyte",task="",wf=""} 10
-			testscope_summary:unittest_count{domain="dev",lp="",project="flyte",task="",wf=""} 1
+			testscope_summary:s1{domain="",project="",task="",wf="",quantile="0.5"} 10
+			testscope_summary:s1{domain="",project="",task="",wf="",quantile="0.9"} 10
+			testscope_summary:s1{domain="",project="",task="",wf="",quantile="0.99"} 10
+			testscope_summary:s1_sum{domain="",project="",task="",wf=""} 10
+			testscope_summary:s1_count{domain="",project="",task="",wf=""} 1
 		`
 		err := testutil.CollectAndCompare(s.SummaryVec, strings.NewReader(header+expected))
 		assert.NoError(t, err)
 
 		s.Observe(ctx, 100)
 		s.Observe(ctx, 1000)
-
 		expected = `
-			testscope_summary:unittest{domain="dev",lp="",project="flyte",task="",wf="",quantile="0.5"} 100
-			testscope_summary:unittest{domain="dev",lp="",project="flyte",task="",wf="",quantile="0.9"} 1000
-			testscope_summary:unittest{domain="dev",lp="",project="flyte",task="",wf="",quantile="0.99"} 1000
-			testscope_summary:unittest_sum{domain="dev",lp="",project="flyte",task="",wf=""} 1110
-			testscope_summary:unittest_count{domain="dev",lp="",project="flyte",task="",wf=""} 3
+			testscope_summary:s1{domain="",project="",task="",wf="",quantile="0.5"} 100
+			testscope_summary:s1{domain="",project="",task="",wf="",quantile="0.9"} 1000
+			testscope_summary:s1{domain="",project="",task="",wf="",quantile="0.99"} 1000
+			testscope_summary:s1_sum{domain="",project="",task="",wf=""} 1110
+			testscope_summary:s1_count{domain="",project="",task="",wf=""} 3
 		`
 		err = testutil.CollectAndCompare(s.SummaryVec, strings.NewReader(header+expected))
 		assert.NoError(t, err)
 
-		s.Observe(contextutils.WithProjectDomain(ctx, "flyte", "prod"), 10)
-
+		ctx = contextutils.WithProjectDomain(ctx, "project", "domain")
+		s.Observe(ctx, 10)
 		expected = `
-			testscope_summary:unittest{domain="dev",lp="",project="flyte",task="",wf="",quantile="0.5"} 100
-			testscope_summary:unittest{domain="dev",lp="",project="flyte",task="",wf="",quantile="0.9"} 1000
-			testscope_summary:unittest{domain="dev",lp="",project="flyte",task="",wf="",quantile="0.99"} 1000
-			testscope_summary:unittest_sum{domain="dev",lp="",project="flyte",task="",wf=""} 1110
-			testscope_summary:unittest_count{domain="dev",lp="",project="flyte",task="",wf=""} 3
-			testscope_summary:unittest{domain="prod",lp="",project="flyte",task="",wf="",quantile="0.5"} 10
-			testscope_summary:unittest{domain="prod",lp="",project="flyte",task="",wf="",quantile="0.9"} 10
-			testscope_summary:unittest{domain="prod",lp="",project="flyte",task="",wf="",quantile="0.99"} 10
-			testscope_summary:unittest_sum{domain="prod",lp="",project="flyte",task="",wf=""} 10
-			testscope_summary:unittest_count{domain="prod",lp="",project="flyte",task="",wf=""} 1
+			testscope_summary:s1{domain="",project="",task="",wf="",quantile="0.5"} 100
+			testscope_summary:s1{domain="",project="",task="",wf="",quantile="0.9"} 1000
+			testscope_summary:s1{domain="",project="",task="",wf="",quantile="0.99"} 1000
+			testscope_summary:s1_sum{domain="",project="",task="",wf=""} 1110
+			testscope_summary:s1_count{domain="",project="",task="",wf=""} 3
+			testscope_summary:s1{domain="domain",project="project",task="",wf="",quantile="0.5"} 10
+			testscope_summary:s1{domain="domain",project="project",task="",wf="",quantile="0.9"} 10
+			testscope_summary:s1{domain="domain",project="project",task="",wf="",quantile="0.99"} 10
+			testscope_summary:s1_sum{domain="domain",project="project",task="",wf=""} 10
+			testscope_summary:s1_count{domain="domain",project="project",task="",wf=""} 1
 		`
 		err = testutil.CollectAndCompare(s.SummaryVec, strings.NewReader(header+expected))
 		assert.NoError(t, err)
 	})
 
-	t.Run("extra labels", func(t *testing.T) {
+	t.Run("Unlabeled", func(t *testing.T) {
+		scope := promutils.NewScope("testscope_summary")
+		s := NewSummary("s2", "some desc", scope, EmitUnlabeledMetric)
+		assert.NotNil(t, s)
+
+		ctx := context.TODO()
+		const header = `
+			# HELP testscope_summary:s2_unlabeled some desc
+			# TYPE testscope_summary:s2_unlabeled summary
+		`
+
+		s.Observe(ctx, 10)
+		var expected = `
+			testscope_summary:s2_unlabeled{quantile="0.5"} 10
+			testscope_summary:s2_unlabeled{quantile="0.9"} 10
+			testscope_summary:s2_unlabeled{quantile="0.99"} 10
+			testscope_summary:s2_unlabeled_sum 10
+			testscope_summary:s2_unlabeled_count 1
+		`
+		err := testutil.CollectAndCompare(s.Summary, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+	})
+
+	/*t.Run("extra labels", func(t *testing.T) {
 		scope := promutils.NewScope("testscope_summary")
 		ctx := context.Background()
-		s := NewSummary("unittest2", "some desc", scope, AdditionalLabelsOption{Labels: []string{"method"}})
+		s := NewSummary("s12", "some desc", scope, AdditionalLabelsOption{Labels: []string{"method"}})
 		assert.NotNil(t, s)
 
 		methodKey := contextutils.Key("method")
@@ -84,46 +105,85 @@ func TestLabeledSummary(t *testing.T) {
 		s.Observe(context.WithValue(ctx, methodKey, "POST"), 100)
 
 		const header = `
-			# HELP testscope_summary:unittest2 some desc
-			# TYPE testscope_summary:unittest2 summary
+			# HELP testscope_summary:s12 some desc
+			# TYPE testscope_summary:s12 summary
 		`
 		var expected = `
-			testscope_summary:unittest2{domain="",lp="",method="GET",project="",task="",wf="",quantile="0.5"} 10
-			testscope_summary:unittest2{domain="",lp="",method="GET",project="",task="",wf="",quantile="0.9"} 10
-			testscope_summary:unittest2{domain="",lp="",method="GET",project="",task="",wf="",quantile="0.99"} 10
-			testscope_summary:unittest2_sum{domain="",lp="",method="GET",project="",task="",wf=""} 10
-			testscope_summary:unittest2_count{domain="",lp="",method="GET",project="",task="",wf=""} 1
-			testscope_summary:unittest2{domain="",lp="",method="POST",project="",task="",wf="",quantile="0.5"} 100
-			testscope_summary:unittest2{domain="",lp="",method="POST",project="",task="",wf="",quantile="0.9"} 100
-			testscope_summary:unittest2{domain="",lp="",method="POST",project="",task="",wf="",quantile="0.99"} 100
-			testscope_summary:unittest2_sum{domain="",lp="",method="POST",project="",task="",wf=""} 100
-			testscope_summary:unittest2_count{domain="",lp="",method="POST",project="",task="",wf=""} 1
+			testscope_summary:s12{domain="",lp="",method="GET",project="",task="",wf="",quantile="0.5"} 10
+			testscope_summary:s12{domain="",lp="",method="GET",project="",task="",wf="",quantile="0.9"} 10
+			testscope_summary:s12{domain="",lp="",method="GET",project="",task="",wf="",quantile="0.99"} 10
+			testscope_summary:s12_sum{domain="",lp="",method="GET",project="",task="",wf=""} 10
+			testscope_summary:s12_count{domain="",lp="",method="GET",project="",task="",wf=""} 1
+			testscope_summary:s12{domain="",lp="",method="POST",project="",task="",wf="",quantile="0.5"} 100
+			testscope_summary:s12{domain="",lp="",method="POST",project="",task="",wf="",quantile="0.9"} 100
+			testscope_summary:s12{domain="",lp="",method="POST",project="",task="",wf="",quantile="0.99"} 100
+			testscope_summary:s12_sum{domain="",lp="",method="POST",project="",task="",wf=""} 100
+			testscope_summary:s12_count{domain="",lp="",method="POST",project="",task="",wf=""} 1
 		`
 		err := testutil.CollectAndCompare(s.SummaryVec, strings.NewReader(header+expected))
 		assert.NoError(t, err)
-	})
+	})*/
 
-	t.Run("unlabeled", func(t *testing.T) {
+	t.Run("AdditionalLabels", func(t *testing.T) {
 		scope := promutils.NewScope("testscope_summary")
-		ctx := context.Background()
-		ctx = contextutils.WithProjectDomain(ctx, "flyte", "dev")
-		s := NewSummary("unittest3", "some desc", scope, EmitUnlabeledMetric)
+		opts := AdditionalLabelsOption{Labels: []string{contextutils.ProjectKey.String(), contextutils.ExecIDKey.String()}}
+		s := NewSummary("s3", "some desc", scope, opts)
 		assert.NotNil(t, s)
 
-		s.Observe(ctx, 10)
-
+		ctx := context.TODO()
 		const header = `
-			# HELP testscope_summary:unittest3_unlabeled some desc
-			# TYPE testscope_summary:unittest3_unlabeled summary
+			# HELP testscope_summary:s3 some desc
+			# TYPE testscope_summary:s3 summary
 		`
+
+		s.Observe(ctx, 10)
 		var expected = `
-			testscope_summary:unittest3_unlabeled{quantile="0.5"} 10
-			testscope_summary:unittest3_unlabeled{quantile="0.9"} 10
-			testscope_summary:unittest3_unlabeled{quantile="0.99"} 10
-			testscope_summary:unittest3_unlabeled_sum 10
-			testscope_summary:unittest3_unlabeled_count 1
+			testscope_summary:s3{domain="",exec_id="",project="",task="",wf="",quantile="0.5"} 10
+			testscope_summary:s3{domain="",exec_id="",project="",task="",wf="",quantile="0.9"} 10
+			testscope_summary:s3{domain="",exec_id="",project="",task="",wf="",quantile="0.99"} 10
+			testscope_summary:s3_sum{domain="",exec_id="",project="",task="",wf=""} 10
+			testscope_summary:s3_count{domain="",exec_id="",project="",task="",wf=""} 1
 		`
-		err := testutil.CollectAndCompare(s.Summary, strings.NewReader(header+expected))
+		err := testutil.CollectAndCompare(s.SummaryVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+
+		ctx = contextutils.WithProjectDomain(ctx, "project", "domain")
+		s.Observe(ctx, 10)
+		expected = `
+			testscope_summary:s3{domain="",exec_id="",project="",task="",wf="",quantile="0.5"} 10
+			testscope_summary:s3{domain="",exec_id="",project="",task="",wf="",quantile="0.9"} 10
+			testscope_summary:s3{domain="",exec_id="",project="",task="",wf="",quantile="0.99"} 10
+			testscope_summary:s3_sum{domain="",exec_id="",project="",task="",wf=""} 10
+			testscope_summary:s3_count{domain="",exec_id="",project="",task="",wf=""} 1
+			testscope_summary:s3{domain="domain",exec_id="",project="project",task="",wf="",quantile="0.5"} 10
+			testscope_summary:s3{domain="domain",exec_id="",project="project",task="",wf="",quantile="0.9"} 10
+			testscope_summary:s3{domain="domain",exec_id="",project="project",task="",wf="",quantile="0.99"} 10
+			testscope_summary:s3_sum{domain="domain",exec_id="",project="project",task="",wf=""} 10
+			testscope_summary:s3_count{domain="domain",exec_id="",project="project",task="",wf=""} 1
+		`
+		err = testutil.CollectAndCompare(s.SummaryVec, strings.NewReader(header+expected))
+		assert.NoError(t, err)
+
+		ctx = contextutils.WithExecutionID(ctx, "exec_id")
+		s.Observe(ctx, 10)
+		expected = `
+			testscope_summary:s3{domain="",exec_id="",project="",task="",wf="",quantile="0.5"} 10
+			testscope_summary:s3{domain="",exec_id="",project="",task="",wf="",quantile="0.9"} 10
+			testscope_summary:s3{domain="",exec_id="",project="",task="",wf="",quantile="0.99"} 10
+			testscope_summary:s3_sum{domain="",exec_id="",project="",task="",wf=""} 10
+			testscope_summary:s3_count{domain="",exec_id="",project="",task="",wf=""} 1
+			testscope_summary:s3{domain="domain",exec_id="",project="project",task="",wf="",quantile="0.5"} 10
+			testscope_summary:s3{domain="domain",exec_id="",project="project",task="",wf="",quantile="0.9"} 10
+			testscope_summary:s3{domain="domain",exec_id="",project="project",task="",wf="",quantile="0.99"} 10
+			testscope_summary:s3_sum{domain="domain",exec_id="",project="project",task="",wf=""} 10
+			testscope_summary:s3_count{domain="domain",exec_id="",project="project",task="",wf=""} 1
+			testscope_summary:s3{domain="domain",exec_id="exec_id",project="project",task="",wf="",quantile="0.5"} 10
+			testscope_summary:s3{domain="domain",exec_id="exec_id",project="project",task="",wf="",quantile="0.9"} 10
+			testscope_summary:s3{domain="domain",exec_id="exec_id",project="project",task="",wf="",quantile="0.99"} 10
+			testscope_summary:s3_sum{domain="domain",exec_id="exec_id",project="project",task="",wf=""} 10
+			testscope_summary:s3_count{domain="domain",exec_id="exec_id",project="project",task="",wf=""} 1
+		`
+		err = testutil.CollectAndCompare(s.SummaryVec, strings.NewReader(header+expected))
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
# TL;DR
This PR computes a unique labels set for each metric on initialization. This is used to popular metric values during increments (so a new slice does not have to be constructed), but more importantly it fixes an issue with corrupting the global metric keys slice.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The Golang `append` function implementation will reuse the underlying slice if it has remaining capacity. In the current implementation, this means that when we construct a new metric with additional labels we may modify the global metricKeys slice. This may result in the corruption of labels within other metrics.


## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2597

## Follow-up issue
_NA_
