### PR TITLE
Adding utils for signal ID context

### DIFF
--- a/contextutils/context.go
+++ b/contextutils/context.go
@@ -24,6 +24,7 @@ const (
 	RoutineLabelKey    Key = "routine"
 	LaunchPlanIDKey    Key = "lp"
 	ResourceVersionKey Key = "res_ver"
+	SignalIDKey        Key = "signal"
 )
 
 func (k Key) String() string {
@@ -124,6 +125,11 @@ func WithTaskID(ctx context.Context, taskID string) context.Context {
 // Gets a new context with TaskType set.
 func WithTaskType(ctx context.Context, taskType string) context.Context {
 	return context.WithValue(ctx, TaskTypeKey, taskType)
+}
+
+// Gets a new context with SignalID set.
+func WithSignalID(ctx context.Context, signalID string) context.Context {
+	return context.WithValue(ctx, SignalIDKey, signalID)
 }
 
 // Gets a new context with Go Routine label key set and a label assigned to the context using pprof.Labels.

--- a/contextutils/context_test.go
+++ b/contextutils/context_test.go
@@ -102,6 +102,13 @@ func TestWithTaskID(t *testing.T) {
 	assert.Equal(t, "task", ctx.Value(TaskIDKey))
 }
 
+func TestWithSignalID(t *testing.T) {
+	ctx := context.Background()
+	assert.Nil(t, ctx.Value(SignalIDKey))
+	ctx = WithSignalID(ctx, "signal")
+	assert.Equal(t, "signal", ctx.Value(SignalIDKey))
+}
+
 func TestGetFields(t *testing.T) {
 	ctx := context.Background()
 	ctx = WithJobID(WithNamespace(ctx, "ns123"), "job123")


### PR DESCRIPTION
# TL;DR
With the additional of the signal service in FlyteAdmin we may want to track metrics on a per-signal basis. To do this we need to set the signal ID on the context.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/208

## Follow-up issue
_NA_
