### PR TITLE
Extract out data store metrics for re-usability

### DIFF
--- a/storage/cached_rawstore.go
+++ b/storage/cached_rawstore.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"runtime/debug"
+	"time"
 
 	"github.com/flyteorg/flytestdlib/errors"
 
@@ -97,6 +98,15 @@ func (s *cachedRawStore) WriteRaw(ctx context.Context, reference DataReference, 
 	}
 
 	return err
+}
+
+func newCacheMetrics(scope promutils.Scope) *cacheMetrics {
+	return &cacheMetrics{
+		FetchLatency:    scope.MustNewStopWatch("remote_fetch", "Total Time to read from remote metastore", time.Millisecond),
+		CacheHit:        scope.MustNewCounter("cache_hit", "Number of times metadata was found in cache"),
+		CacheMiss:       scope.MustNewCounter("cache_miss", "Number of times metadata was not found in cache and remote fetch was required"),
+		CacheWriteError: scope.MustNewCounter("cache_write_err", "Failed to write to cache"),
+	}
 }
 
 // Creates a CachedStore if Caching is enabled, otherwise returns a RawStore

--- a/storage/cached_rawstore.go
+++ b/storage/cached_rawstore.go
@@ -3,15 +3,17 @@ package storage
 import (
 	"bytes"
 	"context"
-	"github.com/flyteorg/flytestdlib/errors"
 	"io"
 	"runtime/debug"
 
+	"github.com/flyteorg/flytestdlib/errors"
+
 	"github.com/coocood/freecache"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/flyteorg/flytestdlib/ioutils"
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 const neverExpire = 0
@@ -98,7 +100,7 @@ func (s *cachedRawStore) WriteRaw(ctx context.Context, reference DataReference, 
 }
 
 // Creates a CachedStore if Caching is enabled, otherwise returns a RawStore
-func newCachedRawStore(cfg *Config, store RawStore, metrics *DataStoreMetrics) RawStore {
+func newCachedRawStore(cfg *Config, store RawStore, metrics *cacheMetrics) RawStore {
 	if cfg.Cache.MaxSizeMegabytes > 0 {
 		if cfg.Cache.TargetGCPercent > 0 {
 			debug.SetGCPercent(cfg.Cache.TargetGCPercent)
@@ -106,7 +108,7 @@ func newCachedRawStore(cfg *Config, store RawStore, metrics *DataStoreMetrics) R
 		return &cachedRawStore{
 			RawStore: store,
 			cache:    freecache.NewCache(cfg.Cache.MaxSizeMegabytes * 1024 * 1024),
-			metrics:  metrics.cacheMetrics,
+			metrics:  metrics,
 		}
 	}
 	return store

--- a/storage/copy_impl.go
+++ b/storage/copy_impl.go
@@ -6,18 +6,18 @@ import (
 	"io"
 	"time"
 
-	"github.com/flyteorg/flytestdlib/logger"
+	errs "github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/flyteorg/flytestdlib/ioutils"
+	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/flyteorg/flytestdlib/promutils/labeled"
-	errs "github.com/pkg/errors"
 )
 
 type copyImpl struct {
 	rawStore RawStore
-	metrics  copyMetrics
+	metrics  *copyMetrics
 }
 
 type copyMetrics struct {
@@ -64,18 +64,11 @@ func (c copyImpl) CopyRaw(ctx context.Context, source, destination DataReference
 	return nil
 }
 
-func newCopyMetrics(scope promutils.Scope) copyMetrics {
-	return copyMetrics{
+func newCopyMetrics(scope promutils.Scope) *copyMetrics {
+	return &copyMetrics{
 		CopyLatency:                  labeled.NewStopWatch("overall", "Overall copy latency", time.Millisecond, scope, labeled.EmitUnlabeledMetric),
 		ComputeLengthLatency:         labeled.NewStopWatch("length", "Latency involved in computing length of content before writing.", time.Millisecond, scope, labeled.EmitUnlabeledMetric),
 		WriteFailureUnrelatedToCache: scope.MustNewCounter("write_failure_unrelated_to_cache", "Raw store write failures that are not caused by ErrFailedToWriteCache"),
 		ReadFailureUnrelatedToCache:  scope.MustNewCounter("read_failure_unrelated_to_cache", "Raw store read failures that are not caused by ErrFailedToWriteCache"),
-	}
-}
-
-func newCopyImpl(store RawStore, metricsScope promutils.Scope) copyImpl {
-	return copyImpl{
-		rawStore: store,
-		metrics:  newCopyMetrics(metricsScope.NewSubScope("copy")),
 	}
 }

--- a/storage/copy_impl.go
+++ b/storage/copy_impl.go
@@ -72,3 +72,10 @@ func newCopyMetrics(scope promutils.Scope) *copyMetrics {
 		ReadFailureUnrelatedToCache:  scope.MustNewCounter("read_failure_unrelated_to_cache", "Raw store read failures that are not caused by ErrFailedToWriteCache"),
 	}
 }
+
+func newCopyImpl(store RawStore, metrics *copyMetrics) copyImpl {
+	return copyImpl{
+		rawStore: store,
+		metrics:  metrics,
+	}
+}

--- a/storage/copy_impl_test.go
+++ b/storage/copy_impl_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/flyteorg/flytestdlib/errors"
 
-	"github.com/flyteorg/flytestdlib/ioutils"
-	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flytestdlib/ioutils"
 )
 
 type notSeekerReader struct {
@@ -44,7 +44,6 @@ func newNotSeekerReader(bytesCount int) *notSeekerReader {
 }
 
 func TestCopyRaw(t *testing.T) {
-	resetMetricKeys()
 	t.Run("Called", func(t *testing.T) {
 		readerCalled := false
 		writerCalled := false
@@ -59,7 +58,7 @@ func TestCopyRaw(t *testing.T) {
 			},
 		}
 
-		copier := newCopyImpl(&store, promutils.NewTestScope())
+		copier := newCopyImpl(&store, metrics.copyMetrics)
 		assert.NoError(t, copier.CopyRaw(context.Background(), DataReference("source.pb"), DataReference("dest.pb"), Options{}))
 		assert.True(t, readerCalled)
 		assert.True(t, writerCalled)
@@ -79,7 +78,7 @@ func TestCopyRaw(t *testing.T) {
 			},
 		}
 
-		copier := newCopyImpl(&store, promutils.NewTestScope())
+		copier := newCopyImpl(&store, metrics.copyMetrics)
 		assert.NoError(t, copier.CopyRaw(context.Background(), DataReference("source.pb"), DataReference("dest.pb"), Options{}))
 		assert.True(t, readerCalled)
 		assert.True(t, writerCalled)
@@ -87,7 +86,6 @@ func TestCopyRaw(t *testing.T) {
 }
 
 func TestCopyRaw_CachingErrorHandling(t *testing.T) {
-	resetMetricKeys()
 	t.Run("CopyRaw with Caching Error", func(t *testing.T) {
 		readerCalled := false
 		writerCalled := false
@@ -108,7 +106,7 @@ func TestCopyRaw_CachingErrorHandling(t *testing.T) {
 			},
 		}
 
-		copier := newCopyImpl(&store, promutils.NewTestScope())
+		copier := newCopyImpl(&store, metrics.copyMetrics)
 		assert.NoError(t, copier.CopyRaw(context.Background(), DataReference("source.pb"), DataReference("dest.pb"), Options{}))
 		assert.True(t, readerCalled)
 		assert.True(t, writerCalled)
@@ -134,7 +132,7 @@ func TestCopyRaw_CachingErrorHandling(t *testing.T) {
 			},
 		}
 
-		copier := newCopyImpl(&store, promutils.NewTestScope())
+		copier := newCopyImpl(&store, metrics.copyMetrics)
 		err = copier.CopyRaw(context.Background(), DataReference("source.pb"), DataReference("dest.pb"), Options{})
 		assert.Error(t, err)
 		assert.True(t, readerCalled)

--- a/storage/init_test.go
+++ b/storage/init_test.go
@@ -1,0 +1,15 @@
+package storage
+
+import (
+	"github.com/flyteorg/flytestdlib/contextutils"
+	"github.com/flyteorg/flytestdlib/promutils"
+	"github.com/flyteorg/flytestdlib/promutils/labeled"
+)
+
+var metrics *dataStoreMetrics
+
+func init() {
+	labeled.SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey)
+	scope := promutils.NewTestScope()
+	metrics = newDataStoreMetrics(scope)
+}

--- a/storage/mem_store.go
+++ b/storage/mem_store.go
@@ -68,14 +68,11 @@ func (s *InMemoryStore) CreateSignedURL(ctx context.Context, reference DataRefer
 	return SignedURLResponse{}, fmt.Errorf("unsupported")
 }
 
-func NewInMemoryRawStore(_ *Config, metrics *DataStoreMetrics) (RawStore, error) {
+func NewInMemoryRawStore(_ *Config, metrics *dataStoreMetrics) (RawStore, error) {
 	self := &InMemoryStore{
 		cache: map[DataReference]rawFile{},
 	}
 
-	self.copyImpl = copyImpl{
-		rawStore: self,
-		metrics:  metrics.copyMetrics,
-	}
+	self.copyImpl = newCopyImpl(self, metrics.copyMetrics)
 	return self, nil
 }

--- a/storage/mem_store.go
+++ b/storage/mem_store.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-
-	"github.com/flyteorg/flytestdlib/promutils"
 )
 
 type rawFile = []byte
@@ -70,11 +68,14 @@ func (s *InMemoryStore) CreateSignedURL(ctx context.Context, reference DataRefer
 	return SignedURLResponse{}, fmt.Errorf("unsupported")
 }
 
-func NewInMemoryRawStore(_ *Config, scope promutils.Scope) (RawStore, error) {
+func NewInMemoryRawStore(_ *Config, metrics *DataStoreMetrics) (RawStore, error) {
 	self := &InMemoryStore{
 		cache: map[DataReference]rawFile{},
 	}
 
-	self.copyImpl = newCopyImpl(self, scope)
+	self.copyImpl = copyImpl{
+		rawStore: self,
+		metrics:  metrics.copyMetrics,
+	}
 	return self, nil
 }

--- a/storage/mem_store_test.go
+++ b/storage/mem_store_test.go
@@ -5,15 +5,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/flyteorg/flytestdlib/promutils"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInMemoryStore_Head(t *testing.T) {
 	t.Run("Empty store", func(t *testing.T) {
-		testScope := promutils.NewTestScope()
-		s, err := NewInMemoryRawStore(&Config{}, testScope)
+		s, err := NewInMemoryRawStore(&Config{}, metrics)
 		assert.NoError(t, err)
 		metadata, err := s.Head(context.TODO(), DataReference("hello"))
 		assert.NoError(t, err)
@@ -21,8 +18,7 @@ func TestInMemoryStore_Head(t *testing.T) {
 	})
 
 	t.Run("Existing Item", func(t *testing.T) {
-		testScope := promutils.NewTestScope()
-		s, err := NewInMemoryRawStore(&Config{}, testScope)
+		s, err := NewInMemoryRawStore(&Config{}, metrics)
 		assert.NoError(t, err)
 		err = s.WriteRaw(context.TODO(), DataReference("hello"), 0, Options{}, bytes.NewReader([]byte{}))
 		assert.NoError(t, err)
@@ -35,8 +31,7 @@ func TestInMemoryStore_Head(t *testing.T) {
 
 func TestInMemoryStore_ReadRaw(t *testing.T) {
 	t.Run("Empty store", func(t *testing.T) {
-		testScope := promutils.NewTestScope()
-		s, err := NewInMemoryRawStore(&Config{}, testScope)
+		s, err := NewInMemoryRawStore(&Config{}, metrics)
 		assert.NoError(t, err)
 
 		raw, err := s.ReadRaw(context.TODO(), DataReference("hello"))
@@ -45,8 +40,7 @@ func TestInMemoryStore_ReadRaw(t *testing.T) {
 	})
 
 	t.Run("Existing Item", func(t *testing.T) {
-		testScope := promutils.NewTestScope()
-		s, err := NewInMemoryRawStore(&Config{}, testScope)
+		s, err := NewInMemoryRawStore(&Config{}, metrics)
 		assert.NoError(t, err)
 
 		err = s.WriteRaw(context.TODO(), DataReference("hello"), 0, Options{}, bytes.NewReader([]byte{}))
@@ -58,8 +52,7 @@ func TestInMemoryStore_ReadRaw(t *testing.T) {
 }
 
 func TestInMemoryStore_Clear(t *testing.T) {
-	testScope := promutils.NewTestScope()
-	m, err := NewInMemoryRawStore(&Config{}, testScope)
+	m, err := NewInMemoryRawStore(&Config{}, metrics)
 	assert.NoError(t, err)
 
 	mStore := m.(*InMemoryStore)

--- a/storage/protobuf_store.go
+++ b/storage/protobuf_store.go
@@ -79,9 +79,9 @@ func (s DefaultProtobufStore) WriteProtobuf(ctx context.Context, reference DataR
 	return nil
 }
 
-func NewDefaultProtobufStore(store RawStore, metrics *DataStoreMetrics) DefaultProtobufStore {
+func NewDefaultProtobufStore(store RawStore, metrics *protoMetrics) DefaultProtobufStore {
 	return DefaultProtobufStore{
 		RawStore: store,
-		metrics:  metrics.protoMetrics,
+		metrics:  metrics,
 	}
 }

--- a/storage/protobuf_store.go
+++ b/storage/protobuf_store.go
@@ -4,16 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"time"
-
-	"github.com/flyteorg/flytestdlib/logger"
-
-	"github.com/flyteorg/flytestdlib/ioutils"
-	"github.com/flyteorg/flytestdlib/promutils"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/golang/protobuf/proto"
 	errs "github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/flyteorg/flytestdlib/ioutils"
+	"github.com/flyteorg/flytestdlib/logger"
+	"github.com/flyteorg/flytestdlib/promutils"
 )
 
 type protoMetrics struct {
@@ -81,17 +79,9 @@ func (s DefaultProtobufStore) WriteProtobuf(ctx context.Context, reference DataR
 	return nil
 }
 
-func NewDefaultProtobufStore(store RawStore, metricsScope promutils.Scope) DefaultProtobufStore {
+func NewDefaultProtobufStore(store RawStore, metrics *DataStoreMetrics) DefaultProtobufStore {
 	return DefaultProtobufStore{
 		RawStore: store,
-		metrics: &protoMetrics{
-			FetchLatency:                 metricsScope.MustNewStopWatch("proto_fetch", "Time to read data before unmarshalling", time.Millisecond),
-			MarshalTime:                  metricsScope.MustNewStopWatch("marshal", "Time incurred in marshalling data before writing", time.Millisecond),
-			UnmarshalTime:                metricsScope.MustNewStopWatch("unmarshal", "Time incurred in unmarshalling received data", time.Millisecond),
-			MarshalFailure:               metricsScope.MustNewCounter("marshal_failure", "Failures when marshalling"),
-			UnmarshalFailure:             metricsScope.MustNewCounter("unmarshal_failure", "Failures when unmarshalling"),
-			WriteFailureUnrelatedToCache: metricsScope.MustNewCounter("write_failure_unrelated_to_cache", "Raw store write failures that are not caused by ErrFailedToWriteCache"),
-			ReadFailureUnrelatedToCache:  metricsScope.MustNewCounter("read_failure_unrelated_to_cache", "Raw store read failures that are not caused by ErrFailedToWriteCache"),
-		},
+		metrics:  metrics.protoMetrics,
 	}
 }

--- a/storage/protobuf_store_test.go
+++ b/storage/protobuf_store_test.go
@@ -107,8 +107,7 @@ func TestDefaultProtobufStore_HardErrors(t *testing.T) {
 			return nil, fmt.Errorf(dummyReadErrorMsg)
 		},
 	}
-	testScope := promutils.NewTestScope()
-	pbErroneousStore := NewDefaultProtobufStore(store, testScope)
+	pbErroneousStore := NewDefaultProtobufStore(store, metrics.protoMetrics)
 	t.Run("Test if hard write errors are handled correctly", func(t *testing.T) {
 		err := pbErroneousStore.WriteProtobuf(ctx, k1, Options{}, &mockProtoMessage{X: 5})
 		assert.False(t, IsFailedWriteToCache(err))

--- a/storage/protobuf_store_test.go
+++ b/storage/protobuf_store_test.go
@@ -42,19 +42,35 @@ func (m mockBigDataProtoMessage) String() string {
 func (mockBigDataProtoMessage) ProtoMessage() {
 }
 
-func TestDefaultProtobufStore_ReadProtobuf(t *testing.T) {
+func TestDefaultProtobufStore(t *testing.T) {
 	t.Run("Read after Write", func(t *testing.T) {
 		testScope := promutils.NewTestScope()
 		s, err := NewDataStore(&Config{Type: TypeMemory}, testScope)
 		assert.NoError(t, err)
 
-		err = s.WriteProtobuf(context.TODO(), DataReference("hello"), Options{}, &mockProtoMessage{X: 5})
+		err = s.WriteProtobuf(context.TODO(), "hello", Options{}, &mockProtoMessage{X: 5})
 		assert.NoError(t, err)
 
 		m := &mockProtoMessage{}
-		err = s.ReadProtobuf(context.TODO(), DataReference("hello"), m)
+		err = s.ReadProtobuf(context.TODO(), "hello", m)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(5), m.X)
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		testScope := promutils.NewTestScope()
+
+		_, err := NewDataStore(&Config{Type: "invalid"}, testScope)
+
+		assert.EqualError(t, err, "type is of an invalid value [invalid]")
+	})
+
+	t.Run("coudln't create store", func(t *testing.T) {
+		testScope := promutils.NewTestScope()
+
+		_, err := NewDataStore(&Config{Type: TypeS3}, testScope)
+
+		assert.EqualError(t, err, "initContainer is required even with `enable-multicontainer`")
 	})
 }
 

--- a/storage/rawstores.go
+++ b/storage/rawstores.go
@@ -3,11 +3,13 @@ package storage
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/flyteorg/flytestdlib/promutils"
+	"github.com/flyteorg/flytestdlib/promutils/labeled"
 )
 
-type dataStoreCreateFn func(cfg *Config, metricsScope promutils.Scope) (RawStore, error)
+type dataStoreCreateFn func(cfg *Config, metrics *DataStoreMetrics) (RawStore, error)
 
 var stores = map[string]dataStoreCreateFn{
 	TypeMemory: NewInMemoryRawStore,
@@ -54,8 +56,51 @@ func createHTTPClient(cfg HTTPClientConfig) *http.Client {
 	return c
 }
 
+type DataStoreMetrics struct {
+	cacheMetrics *cacheMetrics
+	protoMetrics *protoMetrics
+	copyMetrics  *copyMetrics
+	stowMetrics  *stowMetrics
+}
+
+// NewDataStoreMetrics initialises all metrics required for DataStore
+func NewDataStoreMetrics(scope promutils.Scope) *DataStoreMetrics {
+	failureTypeOption := labeled.AdditionalLabelsOption{Labels: []string{FailureTypeLabel.String()}}
+	return &DataStoreMetrics{
+		cacheMetrics: &cacheMetrics{
+			FetchLatency:    scope.MustNewStopWatch("remote_fetch", "Total Time to read from remote metastore", time.Millisecond),
+			CacheHit:        scope.MustNewCounter("cache_hit", "Number of times metadata was found in cache"),
+			CacheMiss:       scope.MustNewCounter("cache_miss", "Number of times metadata was not found in cache and remote fetch was required"),
+			CacheWriteError: scope.MustNewCounter("cache_write_err", "Failed to write to cache"),
+		},
+		protoMetrics: &protoMetrics{
+			FetchLatency:                 scope.MustNewStopWatch("proto_fetch", "Time to read data before unmarshalling", time.Millisecond),
+			MarshalTime:                  scope.MustNewStopWatch("marshal", "Time incurred in marshalling data before writing", time.Millisecond),
+			UnmarshalTime:                scope.MustNewStopWatch("unmarshal", "Time incurred in unmarshalling received data", time.Millisecond),
+			MarshalFailure:               scope.MustNewCounter("marshal_failure", "Failures when marshalling"),
+			UnmarshalFailure:             scope.MustNewCounter("unmarshal_failure", "Failures when unmarshalling"),
+			WriteFailureUnrelatedToCache: scope.MustNewCounter("write_failure_unrelated_to_cache", "Raw store write failures that are not caused by ErrFailedToWriteCache"),
+			ReadFailureUnrelatedToCache:  scope.MustNewCounter("read_failure_unrelated_to_cache", "Raw store read failures that are not caused by ErrFailedToWriteCache"),
+		},
+		copyMetrics: newCopyMetrics(scope.NewSubScope("copy")),
+		stowMetrics: &stowMetrics{
+			BadReference: labeled.NewCounter("bad_key", "Indicates the provided storage reference/key is incorrectly formatted", scope, labeled.EmitUnlabeledMetric),
+			BadContainer: labeled.NewCounter("bad_container", "Indicates request for a container that has not been initialized", scope, labeled.EmitUnlabeledMetric),
+
+			HeadFailure: labeled.NewCounter("head_failure", "Indicates failure in HEAD for a given reference", scope, labeled.EmitUnlabeledMetric),
+			HeadLatency: labeled.NewStopWatch("head", "Indicates time to fetch metadata using the Head API", time.Millisecond, scope, labeled.EmitUnlabeledMetric),
+
+			ReadFailure:     labeled.NewCounter("read_failure", "Indicates failure in GET for a given reference", scope, labeled.EmitUnlabeledMetric, failureTypeOption),
+			ReadOpenLatency: labeled.NewStopWatch("read_open", "Indicates time to first byte when reading", time.Millisecond, scope, labeled.EmitUnlabeledMetric),
+
+			WriteFailure: labeled.NewCounter("write_failure", "Indicates failure in storing/PUT for a given reference", scope, labeled.EmitUnlabeledMetric, failureTypeOption),
+			WriteLatency: labeled.NewStopWatch("write", "Time to write an object irrespective of size", time.Millisecond, scope, labeled.EmitUnlabeledMetric),
+		},
+	}
+}
+
 // NewDataStore creates a new Data Store with the supplied config.
-func NewDataStore(cfg *Config, metricsScope promutils.Scope) (s *DataStore, err error) {
+func NewDataStore(cfg *Config, metrics *DataStoreMetrics) (s *DataStore, err error) {
 	defaultClient := http.DefaultClient
 	defer func() {
 		http.DefaultClient = defaultClient
@@ -65,12 +110,12 @@ func NewDataStore(cfg *Config, metricsScope promutils.Scope) (s *DataStore, err 
 
 	var rawStore RawStore
 	if fn, found := stores[cfg.Type]; found {
-		rawStore, err = fn(cfg, metricsScope)
+		rawStore, err = fn(cfg, metrics)
 		if err != nil {
 			return &emptyStore, err
 		}
 
-		protoStore := NewDefaultProtobufStore(newCachedRawStore(cfg, rawStore, metricsScope), metricsScope)
+		protoStore := NewDefaultProtobufStore(newCachedRawStore(cfg, rawStore, metrics), metrics)
 		return NewCompositeDataStore(NewURLPathConstructor(), protoStore), nil
 	}
 

--- a/storage/rawstores.go
+++ b/storage/rawstores.go
@@ -3,10 +3,8 @@ package storage
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/flyteorg/flytestdlib/promutils"
-	"github.com/flyteorg/flytestdlib/promutils/labeled"
 )
 
 type dataStoreCreateFn func(cfg *Config, metrics *dataStoreMetrics) (RawStore, error)
@@ -65,37 +63,11 @@ type dataStoreMetrics struct {
 
 // newDataStoreMetrics initialises all metrics required for DataStore
 func newDataStoreMetrics(scope promutils.Scope) *dataStoreMetrics {
-	failureTypeOption := labeled.AdditionalLabelsOption{Labels: []string{FailureTypeLabel.String()}}
 	return &dataStoreMetrics{
-		cacheMetrics: &cacheMetrics{
-			FetchLatency:    scope.MustNewStopWatch("remote_fetch", "Total Time to read from remote metastore", time.Millisecond),
-			CacheHit:        scope.MustNewCounter("cache_hit", "Number of times metadata was found in cache"),
-			CacheMiss:       scope.MustNewCounter("cache_miss", "Number of times metadata was not found in cache and remote fetch was required"),
-			CacheWriteError: scope.MustNewCounter("cache_write_err", "Failed to write to cache"),
-		},
-		protoMetrics: &protoMetrics{
-			FetchLatency:                 scope.MustNewStopWatch("proto_fetch", "Time to read data before unmarshalling", time.Millisecond),
-			MarshalTime:                  scope.MustNewStopWatch("marshal", "Time incurred in marshalling data before writing", time.Millisecond),
-			UnmarshalTime:                scope.MustNewStopWatch("unmarshal", "Time incurred in unmarshalling received data", time.Millisecond),
-			MarshalFailure:               scope.MustNewCounter("marshal_failure", "Failures when marshalling"),
-			UnmarshalFailure:             scope.MustNewCounter("unmarshal_failure", "Failures when unmarshalling"),
-			WriteFailureUnrelatedToCache: scope.MustNewCounter("write_failure_unrelated_to_cache", "Raw store write failures that are not caused by ErrFailedToWriteCache"),
-			ReadFailureUnrelatedToCache:  scope.MustNewCounter("read_failure_unrelated_to_cache", "Raw store read failures that are not caused by ErrFailedToWriteCache"),
-		},
-		copyMetrics: newCopyMetrics(scope.NewSubScope("copy")),
-		stowMetrics: &stowMetrics{
-			BadReference: labeled.NewCounter("bad_key", "Indicates the provided storage reference/key is incorrectly formatted", scope, labeled.EmitUnlabeledMetric),
-			BadContainer: labeled.NewCounter("bad_container", "Indicates request for a container that has not been initialized", scope, labeled.EmitUnlabeledMetric),
-
-			HeadFailure: labeled.NewCounter("head_failure", "Indicates failure in HEAD for a given reference", scope, labeled.EmitUnlabeledMetric),
-			HeadLatency: labeled.NewStopWatch("head", "Indicates time to fetch metadata using the Head API", time.Millisecond, scope, labeled.EmitUnlabeledMetric),
-
-			ReadFailure:     labeled.NewCounter("read_failure", "Indicates failure in GET for a given reference", scope, labeled.EmitUnlabeledMetric, failureTypeOption),
-			ReadOpenLatency: labeled.NewStopWatch("read_open", "Indicates time to first byte when reading", time.Millisecond, scope, labeled.EmitUnlabeledMetric),
-
-			WriteFailure: labeled.NewCounter("write_failure", "Indicates failure in storing/PUT for a given reference", scope, labeled.EmitUnlabeledMetric, failureTypeOption),
-			WriteLatency: labeled.NewStopWatch("write", "Time to write an object irrespective of size", time.Millisecond, scope, labeled.EmitUnlabeledMetric),
-		},
+		cacheMetrics: newCacheMetrics(scope),
+		protoMetrics: newProtoMetrics(scope),
+		copyMetrics:  newCopyMetrics(scope.NewSubScope("copy")),
+		stowMetrics:  newStowMetrics(scope),
 	}
 }
 

--- a/storage/rawstores.go
+++ b/storage/rawstores.go
@@ -85,6 +85,8 @@ func NewCompositeDataStore(refConstructor ReferenceConstructor, composedProtobuf
 	}
 }
 
+// RefreshConfig re-initialises the data store client leaving metrics untouched.
+// This is NOT thread-safe!
 func (ds *DataStore) RefreshConfig(cfg *Config) error {
 	defaultClient := http.DefaultClient
 	defer func() {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -41,6 +41,7 @@ type Metadata interface {
 type DataStore struct {
 	ComposedProtobufStore
 	ReferenceConstructor
+	metrics *dataStoreMetrics
 }
 
 // SignedURLProperties encapsulates properties about the signedURL operation.

--- a/storage/stow_store.go
+++ b/storage/stow_store.go
@@ -340,7 +340,7 @@ func (s *StowStore) getLocation(id locationID) stow.Location {
 	}
 }
 
-func NewStowRawStore(baseContainerFQN DataReference, loc, signedURLLoc stow.Location, enableDynamicContainerLoading bool, metrics *DataStoreMetrics) (*StowStore, error) {
+func NewStowRawStore(baseContainerFQN DataReference, loc, signedURLLoc stow.Location, enableDynamicContainerLoading bool, metrics *dataStoreMetrics) (*StowStore, error) {
 	self := &StowStore{
 		loc:                           loc,
 		signedURLLoc:                  signedURLLoc,
@@ -350,7 +350,7 @@ func NewStowRawStore(baseContainerFQN DataReference, loc, signedURLLoc stow.Loca
 		metrics:                       metrics.stowMetrics,
 	}
 
-	self.copyImpl = copyImpl{rawStore: self, metrics: metrics.copyMetrics}
+	self.copyImpl = newCopyImpl(self, metrics.copyMetrics)
 	_, c, _, err := baseContainerFQN.Split()
 	if err != nil {
 		return nil, err
@@ -364,7 +364,7 @@ func NewStowRawStore(baseContainerFQN DataReference, loc, signedURLLoc stow.Loca
 }
 
 // Constructor for the StowRawStore
-func newStowRawStore(cfg *Config, metrics *DataStoreMetrics) (RawStore, error) {
+func newStowRawStore(cfg *Config, metrics *dataStoreMetrics) (RawStore, error) {
 	if cfg.InitContainer == "" {
 		return nil, fmt.Errorf("initContainer is required even with `enable-multicontainer`")
 	}

--- a/storage/stow_store.go
+++ b/storage/stow_store.go
@@ -7,27 +7,22 @@ import (
 	"net/url"
 	"strconv"
 	"sync"
-	"time"
-
-	"github.com/flyteorg/flytestdlib/errors"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	s32 "github.com/aws/aws-sdk-go/service/s3"
+	"github.com/flyteorg/stow"
 	"github.com/flyteorg/stow/azure"
 	"github.com/flyteorg/stow/google"
 	"github.com/flyteorg/stow/local"
 	"github.com/flyteorg/stow/oracle"
 	"github.com/flyteorg/stow/s3"
 	"github.com/flyteorg/stow/swift"
+	errs "github.com/pkg/errors"
 
 	"github.com/flyteorg/flytestdlib/contextutils"
+	"github.com/flyteorg/flytestdlib/errors"
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils/labeled"
-
-	"github.com/flyteorg/flytestdlib/promutils"
-
-	"github.com/flyteorg/stow"
-	errs "github.com/pkg/errors"
 )
 
 const (
@@ -345,30 +340,17 @@ func (s *StowStore) getLocation(id locationID) stow.Location {
 	}
 }
 
-func NewStowRawStore(baseContainerFQN DataReference, loc, signedURLLoc stow.Location, enableDynamicContainerLoading bool, metricsScope promutils.Scope) (*StowStore, error) {
-	failureTypeOption := labeled.AdditionalLabelsOption{Labels: []string{FailureTypeLabel.String()}}
+func NewStowRawStore(baseContainerFQN DataReference, loc, signedURLLoc stow.Location, enableDynamicContainerLoading bool, metrics *DataStoreMetrics) (*StowStore, error) {
 	self := &StowStore{
 		loc:                           loc,
 		signedURLLoc:                  signedURLLoc,
 		baseContainerFQN:              baseContainerFQN,
 		enableDynamicContainerLoading: enableDynamicContainerLoading,
 		dynamicContainerMap:           sync.Map{},
-		metrics: &stowMetrics{
-			BadReference: labeled.NewCounter("bad_key", "Indicates the provided storage reference/key is incorrectly formatted", metricsScope, labeled.EmitUnlabeledMetric),
-			BadContainer: labeled.NewCounter("bad_container", "Indicates request for a container that has not been initialized", metricsScope, labeled.EmitUnlabeledMetric),
-
-			HeadFailure: labeled.NewCounter("head_failure", "Indicates failure in HEAD for a given reference", metricsScope, labeled.EmitUnlabeledMetric),
-			HeadLatency: labeled.NewStopWatch("head", "Indicates time to fetch metadata using the Head API", time.Millisecond, metricsScope, labeled.EmitUnlabeledMetric),
-
-			ReadFailure:     labeled.NewCounter("read_failure", "Indicates failure in GET for a given reference", metricsScope, labeled.EmitUnlabeledMetric, failureTypeOption),
-			ReadOpenLatency: labeled.NewStopWatch("read_open", "Indicates time to first byte when reading", time.Millisecond, metricsScope, labeled.EmitUnlabeledMetric),
-
-			WriteFailure: labeled.NewCounter("write_failure", "Indicates failure in storing/PUT for a given reference", metricsScope, labeled.EmitUnlabeledMetric, failureTypeOption),
-			WriteLatency: labeled.NewStopWatch("write", "Time to write an object irrespective of size", time.Millisecond, metricsScope, labeled.EmitUnlabeledMetric),
-		},
+		metrics:                       metrics.stowMetrics,
 	}
 
-	self.copyImpl = newCopyImpl(self, metricsScope)
+	self.copyImpl = copyImpl{rawStore: self, metrics: metrics.copyMetrics}
 	_, c, _, err := baseContainerFQN.Split()
 	if err != nil {
 		return nil, err
@@ -382,7 +364,7 @@ func NewStowRawStore(baseContainerFQN DataReference, loc, signedURLLoc stow.Loca
 }
 
 // Constructor for the StowRawStore
-func newStowRawStore(cfg *Config, metricsScope promutils.Scope) (RawStore, error) {
+func newStowRawStore(cfg *Config, metrics *DataStoreMetrics) (RawStore, error) {
 	if cfg.InitContainer == "" {
 		return nil, fmt.Errorf("initContainer is required even with `enable-multicontainer`")
 	}
@@ -419,7 +401,7 @@ func newStowRawStore(cfg *Config, metricsScope promutils.Scope) (RawStore, error
 		}
 	}
 
-	return NewStowRawStore(fn(cfg.InitContainer), loc, signedURLLoc, cfg.MultiContainerEnabled, metricsScope)
+	return NewStowRawStore(fn(cfg.InitContainer), loc, signedURLLoc, cfg.MultiContainerEnabled, metrics)
 }
 
 func legacyS3ConfigMap(cfg ConnectionConfig) stow.ConfigMap {


### PR DESCRIPTION
# TL;DR
Adjust DataStore to allow initialising it multiple times during a single application run.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
