### PR TITLE
DefaultProtobufStore constructor accepts scope as well as metrics

### DIFF
--- a/storage/mocks/composed_protobuf_store.go
+++ b/storage/mocks/composed_protobuf_store.go
@@ -89,6 +89,38 @@ func (_m *ComposedProtobufStore) CreateSignedURL(ctx context.Context, reference 
 	return r0, r1
 }
 
+type ComposedProtobufStore_Delete struct {
+	*mock.Call
+}
+
+func (_m ComposedProtobufStore_Delete) Return(_a0 error) *ComposedProtobufStore_Delete {
+	return &ComposedProtobufStore_Delete{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *ComposedProtobufStore) OnDelete(ctx context.Context, reference storage.DataReference) *ComposedProtobufStore_Delete {
+	c := _m.On("Delete", ctx, reference)
+	return &ComposedProtobufStore_Delete{Call: c}
+}
+
+func (_m *ComposedProtobufStore) OnDeleteMatch(matchers ...interface{}) *ComposedProtobufStore_Delete {
+	c := _m.On("Delete", matchers...)
+	return &ComposedProtobufStore_Delete{Call: c}
+}
+
+// Delete provides a mock function with given fields: ctx, reference
+func (_m *ComposedProtobufStore) Delete(ctx context.Context, reference storage.DataReference) error {
+	ret := _m.Called(ctx, reference)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, storage.DataReference) error); ok {
+		r0 = rf(ctx, reference)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type ComposedProtobufStore_GetBaseContainerFQN struct {
 	*mock.Call
 }

--- a/storage/mocks/raw_store.go
+++ b/storage/mocks/raw_store.go
@@ -87,6 +87,38 @@ func (_m *RawStore) CreateSignedURL(ctx context.Context, reference storage.DataR
 	return r0, r1
 }
 
+type RawStore_Delete struct {
+	*mock.Call
+}
+
+func (_m RawStore_Delete) Return(_a0 error) *RawStore_Delete {
+	return &RawStore_Delete{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *RawStore) OnDelete(ctx context.Context, reference storage.DataReference) *RawStore_Delete {
+	c := _m.On("Delete", ctx, reference)
+	return &RawStore_Delete{Call: c}
+}
+
+func (_m *RawStore) OnDeleteMatch(matchers ...interface{}) *RawStore_Delete {
+	c := _m.On("Delete", matchers...)
+	return &RawStore_Delete{Call: c}
+}
+
+// Delete provides a mock function with given fields: ctx, reference
+func (_m *RawStore) Delete(ctx context.Context, reference storage.DataReference) error {
+	ret := _m.Called(ctx, reference)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, storage.DataReference) error); ok {
+		r0 = rf(ctx, reference)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type RawStore_GetBaseContainerFQN struct {
 	*mock.Call
 }

--- a/storage/protobuf_store.go
+++ b/storage/protobuf_store.go
@@ -92,7 +92,11 @@ func newProtoMetrics(scope promutils.Scope) *protoMetrics {
 	}
 }
 
-func NewDefaultProtobufStore(store RawStore, metrics *protoMetrics) DefaultProtobufStore {
+func NewDefaultProtobufStore(store RawStore, scope promutils.Scope) DefaultProtobufStore {
+	return NewDefaultProtobufStoreWithMetrics(store, newProtoMetrics(scope))
+}
+
+func NewDefaultProtobufStoreWithMetrics(store RawStore, metrics *protoMetrics) DefaultProtobufStore {
 	return DefaultProtobufStore{
 		RawStore: store,
 		metrics:  metrics,

--- a/storage/protobuf_store_test.go
+++ b/storage/protobuf_store_test.go
@@ -157,7 +157,7 @@ func TestDefaultProtobufStore_HardErrors(t *testing.T) {
 			return nil, fmt.Errorf(dummyReadErrorMsg)
 		},
 	}
-	pbErroneousStore := NewDefaultProtobufStore(store, metrics.protoMetrics)
+	pbErroneousStore := NewDefaultProtobufStoreWithMetrics(store, metrics.protoMetrics)
 	t.Run("Test if hard write errors are handled correctly", func(t *testing.T) {
 		err := pbErroneousStore.WriteProtobuf(ctx, k1, Options{}, &mockProtoMessage{X: 5})
 		assert.False(t, IsFailedWriteToCache(err))

--- a/storage/rawstores.go
+++ b/storage/rawstores.go
@@ -106,7 +106,7 @@ func (ds *DataStore) RefreshConfig(cfg *Config) error {
 	}
 
 	rawStore = newCachedRawStore(cfg, rawStore, ds.metrics.cacheMetrics)
-	protoStore := NewDefaultProtobufStore(rawStore, ds.metrics.protoMetrics)
+	protoStore := NewDefaultProtobufStoreWithMetrics(rawStore, ds.metrics.protoMetrics)
 	newDS := NewCompositeDataStore(NewURLPathConstructor(), protoStore)
 	newDS.metrics = ds.metrics
 	*ds = *newDS


### PR DESCRIPTION
# TL;DR
NewDefaultProtobufStore was changed to expect `protoMetrics` instead of a `promutils.Scope` in #138. Some of propeller's tests need to instantiate it as well using just a scope.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
A few tests in propeller construct a `CompositeDataStore` (and thus a `DefaultProtobufStore`) directly. Since `protoMetrics` and the new `newProtoMetrics` constructor are not exported, the `storage.NewDefaultProtobufStore` constructor can no longer be called.
We could export `newProtoMetrics`, however I've opted to add a contructor "overload" `NewDefaultProtobufStoreWithMetrics` and changed `NewDefaultProtobufStore` to reflect the old signature (accepting a `promutils.Scope`) again.

It also looks like my last PR #140 did not include all generated mocks, so the output of `make generate` was added as well.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
