### PR TITLE
Bump master workflow go versions to 1.18

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: "0"
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: Unit Tests
         run: make mod_download && make test_unit_codecov
       - name: Push CodeCov
@@ -65,7 +65,7 @@ jobs:
           fail_ci_if_error: true
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: Lint
         run: make install && make lint
       - name: Bench tests


### PR DESCRIPTION
# TL;DR
[A previous PR](https://github.com/flyteorg/flytestdlib/pull/133) bumped all go versions to 1.18, but forgot the master workflow. This means that while pull request checks will succeed (with version 1.18) all of the check on merges will fail (go version 1.17) and consequently all releases of this repo have failed since the update. This PR fixes the go version in the master workflow so that merge checks will succeed and a new release can be published.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue
_NA_

## Follow-up issue
_NA_
