### PR TITLE
codecov action version bump

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Unit Tests
         run: make mod_download && make test_unit_codecov
       - name: Push CodeCov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: coverage.txt
           flags: unittests

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,3 @@ compile:
 .PHONY: test_unit_codecov
 test_unit_codecov:
 	go test ./... -race -coverprofile=coverage.txt -covermode=atomic
-	curl -s https://codecov.io/bash > codecov_bash.sh && bash codecov_bash.sh


### PR DESCRIPTION
Code coverage action is failing. It can be because we're using a [deprecated version of codecov uploader bash](https://github.com/codecov/codecov-bash) script. I removed it and bumped up the version of codecov action to push the coverage report to codecov servers

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Refer to [codecov github readme](https://github.com/codecov/codecov-bash#%EF%B8%8F-deprecation-warning-%EF%B8%8F)

## Tracking Issue
_NA_

## Follow-up issue
_NA_
