### PR TITLE
Ignore codecov upload failures

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           file: coverage.txt
           flags: unittests
-          fail_ci_if_error: true
+          fail_ci_if_error: false
       - uses: actions/setup-go@v2
         with:
           go-version: '1.18'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Unit Tests
         run: make mod_download && make test_unit_codecov
       - name: Push CodeCov
-        uses: codecov/codecov-action@v1.5.2
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: coverage.txt
           flags: unittests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           file: coverage.txt
           flags: unittests
-          fail_ci_if_error: true
+          fail_ci_if_error: false
       - name: Bench tests
         run: make install && make test_benchmark
   lint:


### PR DESCRIPTION
# TL;DR
This PR allows the github worklow to succeed even if codecov upload fails.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_