### PR TITLE
Extend length of docs section to 120 characters

### DIFF
--- a/config/config_cmd.go
+++ b/config/config_cmd.go
@@ -16,11 +16,12 @@ import (
 )
 
 const (
-	PathFlag        = "file"
-	StrictModeFlag  = "strict"
-	CommandValidate = "validate"
-	CommandDiscover = "discover"
-	CommandDocs     = "docs"
+	PathFlag          = "file"
+	StrictModeFlag    = "strict"
+	CommandValidate   = "validate"
+	CommandDiscover   = "discover"
+	CommandDocs       = "docs"
+	DocsSectionLength = 120
 )
 
 type AccessorProvider func(options Options) Accessor
@@ -182,10 +183,10 @@ func printToc(orderedSectionKeys sets.String) {
 func printTitle(title string, isSubsection bool) {
 	if isSubsection {
 		fmt.Println(title)
-		fmt.Println(strings.Repeat("^", 80))
+		fmt.Println(strings.Repeat("^", DocsSectionLength))
 	} else {
 		fmt.Println("Section:", title)
-		fmt.Println(strings.Repeat("=", 80))
+		fmt.Println(strings.Repeat("=", DocsSectionLength))
 	}
 	fmt.Println()
 }
@@ -198,7 +199,7 @@ func printSection(name string, dataType string, defaultValue string, description
 
 	fmt.Printf("%s ", name)
 	fmt.Printf("(%s)\n", dataType)
-	fmt.Println(strings.Repeat(c, 80))
+	fmt.Println(strings.Repeat(c, DocsSectionLength))
 	fmt.Println()
 	if description != "" {
 		fmt.Printf("%s\n\n", description)


### PR DESCRIPTION
# TL;DR
Extend the length of sections produced by the `config docs` subcommand to 120 characters

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
https://github.com/flyteorg/flyte/pull/3819 is failing due to invalid markdown. This PR increases the length of the section from 80 characters to 120 characters.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
