### PR TITLE
Only enqueue non-terminal tasks

### DIFF
--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -265,6 +265,7 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 			return nil
 		default:
 			item, shutdown := w.workqueue.Get()
+			logger.Infof(ctx, "Got item from workqueue: %v", (*item.(*Batch))[0].GetID())
 			if shutdown {
 				return nil
 			}

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -219,7 +219,7 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 		// If not ok, it means evicted between the item was evicted between getting the keys and this update loop
 		// which is fine, we can just ignore.
 		if value, ok := w.lruMap.Peek(k); ok {
-			if item, ok := value.(Item); ok && !item.IsTerminal() {
+			if item, ok := value.(Item); !ok || (ok && !item.IsTerminal()) {
 				snapshot = append(snapshot, itemWrapper{
 					id:   k.(ItemID),
 					item: value.(Item),

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -81,9 +81,6 @@ const (
 
 	// The item returned has been updated and should be updated in the cache
 	Update
-
-	// The item should be removed from the cache
-	Delete
 )
 
 // SyncFunc func type. Your implementation of this function for your cache instance is responsible for returning

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -218,11 +218,13 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 		}
 		// If not ok, it means evicted between the item was evicted between getting the keys and this update loop
 		// which is fine, we can just ignore.
-		if value, ok := w.lruMap.Peek(k); ok && !value.(Item).IsTerminal() {
-			snapshot = append(snapshot, itemWrapper{
-				id:   k.(ItemID),
-				item: value.(Item),
-			})
+		if value, ok := w.lruMap.Peek(k); ok {
+			if item, ok := value.(Item); ok && item.IsTerminal() {
+				snapshot = append(snapshot, itemWrapper{
+					id:   k.(ItemID),
+					item: value.(Item),
+				})
+			}
 		}
 	}
 

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -57,7 +57,7 @@ type metrics struct {
 }
 
 type Item interface {
-	isTerminal() bool
+	IsTerminal() bool
 }
 
 // Items are wrapped inside an ItemWrapper to be stored in the cache.

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -270,8 +270,6 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 			return nil
 		default:
 			item, shutdown := w.workqueue.Get()
-			batch := (*item.(*Batch))[0]
-			logger.Infof(ctx, "Got item from workqueue: %v", batch.GetID())
 			if shutdown {
 				return nil
 			}
@@ -303,6 +301,7 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 				w.toDelete.Remove(key)
 				return true
 			})
+
 			t.Stop()
 		}
 	}

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -81,6 +81,9 @@ const (
 
 	// The item returned has been updated and should be updated in the cache
 	Update
+
+	// The item should be removed from the cache
+	Delete
 )
 
 // SyncFunc func type. Your implementation of this function for your cache instance is responsible for returning
@@ -272,7 +275,7 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 			if shutdown {
 				return nil
 			}
-			if batch.GetItem().isTerminal() {
+			if batch.GetItem().IsTerminal() {
 				w.workqueue.Forget(item)
 				w.workqueue.Done(item)
 				continue

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -219,7 +219,7 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 		// If not ok, it means evicted between the item was evicted between getting the keys and this update loop
 		// which is fine, we can just ignore.
 		if value, ok := w.lruMap.Peek(k); ok {
-			if item, ok := value.(Item); ok && item.IsTerminal() {
+			if item, ok := value.(Item); ok && !item.IsTerminal() {
 				snapshot = append(snapshot, itemWrapper{
 					id:   k.(ItemID),
 					item: value.(Item),

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -211,9 +211,14 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 
 	snapshot := make([]ItemWrapper, 0, len(keys))
 	for _, k := range keys {
+		if w.toDelete.Contains(k) {
+			w.lruMap.Remove(k)
+			w.toDelete.Remove(k)
+			continue
+		}
 		// If not ok, it means evicted between the item was evicted between getting the keys and this update loop
 		// which is fine, we can just ignore.
-		if value, ok := w.lruMap.Peek(k); ok && !w.toDelete.Contains(k) && !value.(Item).IsTerminal() {
+		if value, ok := w.lruMap.Peek(k); ok && !value.(Item).IsTerminal() {
 			snapshot = append(snapshot, itemWrapper{
 				id:   k.(ItemID),
 				item: value.(Item),

--- a/cache/auto_refresh_example_test.go
+++ b/cache/auto_refresh_example_test.go
@@ -26,6 +26,10 @@ type ExampleCacheItem struct {
 	id     string
 }
 
+func (e *ExampleCacheItem) IsTerminal() bool {
+	return e.status == ExampleStatusSucceeded
+}
+
 func (e *ExampleCacheItem) ID() string {
 	return e.id
 }

--- a/cache/auto_refresh_test.go
+++ b/cache/auto_refresh_test.go
@@ -62,7 +62,7 @@ func syncTerminalItem(_ context.Context, batch Batch) ([]ItemSyncResponse, error
 	panic("This should never be called")
 }
 
-func TestCacheTwo(t *testing.T) {
+func TestCacheThree(t *testing.T) {
 	testResyncPeriod := time.Millisecond
 	rateLimiter := workqueue.DefaultControllerRateLimiter()
 

--- a/cache/auto_refresh_test.go
+++ b/cache/auto_refresh_test.go
@@ -25,6 +25,18 @@ type fakeCacheItem struct {
 	val int
 }
 
+func (f fakeCacheItem) IsTerminal() bool {
+	return false
+}
+
+type terminalCacheItem struct {
+	val int
+}
+
+func (t terminalCacheItem) IsTerminal() bool {
+	return true
+}
+
 func syncFakeItem(_ context.Context, batch Batch) ([]ItemSyncResponse, error) {
 	items := make([]ItemSyncResponse, 0, len(batch))
 	for _, obj := range batch {
@@ -44,6 +56,10 @@ func syncFakeItem(_ context.Context, batch Batch) ([]ItemSyncResponse, error) {
 	}
 
 	return items, nil
+}
+
+func syncTerminalItem(_ context.Context, batch Batch) ([]ItemSyncResponse, error) {
+	panic("This should never be called")
 }
 
 func TestCacheTwo(t *testing.T) {
@@ -104,6 +120,28 @@ func TestCacheTwo(t *testing.T) {
 
 		cancel()
 	})
+
+	t.Run("Enqueue nothing", func(t *testing.T) {
+		cache, err := NewAutoRefreshCache("fake3", syncTerminalItem, rateLimiter, testResyncPeriod, 10, 2, promutils.NewTestScope())
+		assert.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		assert.NoError(t, cache.Start(ctx))
+
+		// Create ten items in the cache
+		for i := 1; i <= 10; i++ {
+			_, err := cache.GetOrCreate(fmt.Sprintf("%d", i), terminalCacheItem{
+				val: 0,
+			})
+			assert.NoError(t, err)
+		}
+
+		// Wait half a second for all resync periods to complete
+		// If the cache tries to enqueue the item, a panic will be thrown.
+		time.Sleep(500 * time.Millisecond)
+
+		cancel()
+	})
 }
 
 func TestQueueBuildUp(t *testing.T) {
@@ -134,7 +172,7 @@ func TestQueueBuildUp(t *testing.T) {
 	defer cancelNow()
 
 	for i := 0; i < size; i++ {
-		_, err := cache.GetOrCreate(strconv.Itoa(i), "test")
+		_, err := cache.GetOrCreate(strconv.Itoa(i), fakeCacheItem{val: 3})
 		assert.NoError(t, err)
 	}
 

--- a/utils/auto_refresh_cache.go
+++ b/utils/auto_refresh_cache.go
@@ -42,9 +42,6 @@ const (
 
 	// The item returned has been updated and should be updated in the cache
 	Update
-
-	// The item should be removed from the cache
-	Delete
 )
 
 // CacheSyncItem is a func type. Your implementation of this function for your cache instance is responsible for returning

--- a/utils/auto_refresh_cache.go
+++ b/utils/auto_refresh_cache.go
@@ -42,6 +42,9 @@ const (
 
 	// The item returned has been updated and should be updated in the cache
 	Update
+
+	// The item should be removed from the cache
+	Delete
 )
 
 // CacheSyncItem is a func type. Your implementation of this function for your cache instance is responsible for returning


### PR DESCRIPTION
# TL;DR
I find that Propeller tries to process the completed task from the `workqueue` because we enqueue the completed item. we should check the item's status before we enqueue them.

Problem:

| Time  | WorkQueue | [Worker](https://github.com/flyteorg/flytestdlib/blob/a8f2b07cd8434b11d9aef9ff7e6d04f7ded4f838/cache/auto_refresh.go#L156-L162) | node Evaluation | 
| ------------- | ------------ |------------- | -----------|
| T1  | Add item1  |                   |      |
| T2  |   |                Process item1  (job finish)       |        |
| T3  | Add item1  |        |         |
| T4  |  |               Process item1  again        |        |
| T5  |  |                       |   Update the node status (running -> succeed)      |

After:

| Time  | WorkQueue | [Worker](https://github.com/flyteorg/flytestdlib/blob/a8f2b07cd8434b11d9aef9ff7e6d04f7ded4f838/cache/auto_refresh.go#L156-L162) | node Evaluation | 
| ------------- | ------------ |------------- | -----------|
| T1  | Add item1  |                   |      |
| T2  |   |                Process item1  (job finish)       |        |
| T3  |  |        |         |
| T4  |  |                     |        |
| T5  |  |                       |   Update the node status (running -> succeed)      |

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
