### PR TITLE
Add item ID to the workqueue instead

### DIFF
--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -235,7 +235,7 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 
 	for _, batch := range batches {
 		b := batch
-		w.workqueue.Add(&b)
+		w.workqueue.Add(b)
 	}
 
 	return nil

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -235,7 +235,7 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 
 	for _, batch := range batches {
 		b := batch
-		w.workqueue.Add(b)
+		w.workqueue.Add(b[0])
 	}
 
 	return nil
@@ -279,7 +279,7 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 			}
 
 			t := w.metrics.SyncLatency.Start()
-			updatedBatch, err := w.syncCb(ctx, *item.(*Batch))
+			updatedBatch, err := w.syncCb(ctx, Batch{item.(ItemWrapper)})
 
 			// Since we create batches every time we sync, we will just remove the item from the queue here
 			// regardless of whether it succeeded the sync or not.

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -235,7 +235,7 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 
 	for _, batch := range batches {
 		for _, b := range batch {
-			logger.Infof(ctx, "Enqueuing batch with id: %v", b.GetID())
+			logger.Debugf(ctx, "Enqueuing batch with id: %v", b.GetID())
 			w.workqueue.Add(b.GetID())
 		}
 	}
@@ -277,12 +277,12 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 		default:
 			itemID, shutdown := w.workqueue.Get()
 			if shutdown {
-				logger.Infof(ctx, "Shutting down worker")
+				logger.Debugf(ctx, "Shutting down worker")
 				return nil
 			}
 
 			t := w.metrics.SyncLatency.Start()
-			logger.Infof(ctx, "Syncing item with id [%v]", itemID)
+			logger.Debugf(ctx, "Syncing item with id [%v]", itemID)
 			item, ok := w.lruMap.Get(itemID)
 			if !ok {
 				logger.Debugf(ctx, "item with id [%v] not found in cache", itemID)

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -214,6 +214,8 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 		if w.toDelete.Contains(k) {
 			w.lruMap.Remove(k)
 			w.toDelete.Remove(k)
+			w.workqueue.Forget(k)
+			w.workqueue.Done(k)
 			continue
 		}
 		// If not ok, it means evicted between the item was evicted between getting the keys and this update loop
@@ -293,11 +295,6 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 				item: item.(Item),
 			}})
 
-			// Since we create batches every time we sync, we will just remove the item from the queue here
-			// regardless of whether it succeeded the sync or not.
-			w.workqueue.Forget(itemID)
-			w.workqueue.Done(itemID)
-
 			if err != nil {
 				w.metrics.SyncErrors.Inc()
 				logger.Errorf(ctx, "failed to get latest copy of a batch. Error: %v", err)
@@ -315,6 +312,8 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 			w.toDelete.Range(func(key interface{}) bool {
 				w.lruMap.Remove(key)
 				w.toDelete.Remove(key)
+				w.workqueue.Forget(itemID)
+				w.workqueue.Done(itemID)
 				return true
 			})
 

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -313,12 +313,6 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 				}
 			}
 
-			w.toDelete.Range(func(key interface{}) bool {
-				w.lruMap.Remove(key)
-				w.toDelete.Remove(key)
-				return true
-			})
-
 			t.Stop()
 		}
 	}

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -285,7 +285,10 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 				logger.Infof(ctx, "item with id [%v] not found in cache", itemId)
 				return nil
 			}
-			updatedBatch, err := w.syncCb(ctx, Batch{item.(ItemWrapper)})
+			updatedBatch, err := w.syncCb(ctx, Batch{itemWrapper{
+				id:   itemId.(ItemID),
+				item: item.(Item),
+			}})
 
 			// Since we create batches every time we sync, we will just remove the item from the queue here
 			// regardless of whether it succeeded the sync or not.

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -286,7 +286,7 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 			item, ok := w.lruMap.Get(itemID)
 			if !ok {
 				logger.Debugf(ctx, "item with id [%v] not found in cache", itemID)
-				return nil
+				continue
 			}
 			updatedBatch, err := w.syncCb(ctx, Batch{itemWrapper{
 				id:   itemID.(ItemID),

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -293,8 +293,8 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 				item: item.(Item),
 			}})
 
-			w.workqueue.Forget(itemID)
-			w.workqueue.Done(itemID)
+			w.workqueue.Forget(item)
+			w.workqueue.Done(item)
 
 			if err != nil {
 				w.metrics.SyncErrors.Inc()

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -286,6 +286,7 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 			item, ok := w.lruMap.Get(itemID)
 			if !ok {
 				logger.Debugf(ctx, "item with id [%v] not found in cache", itemID)
+				t.Stop()
 				continue
 			}
 			updatedBatch, err := w.syncCb(ctx, Batch{itemWrapper{

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -214,8 +214,6 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 		if w.toDelete.Contains(k) {
 			w.lruMap.Remove(k)
 			w.toDelete.Remove(k)
-			w.workqueue.Forget(k)
-			w.workqueue.Done(k)
 			continue
 		}
 		// If not ok, it means evicted between the item was evicted between getting the keys and this update loop
@@ -295,6 +293,9 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 				item: item.(Item),
 			}})
 
+			w.workqueue.Forget(itemID)
+			w.workqueue.Done(itemID)
+
 			if err != nil {
 				w.metrics.SyncErrors.Inc()
 				logger.Errorf(ctx, "failed to get latest copy of a batch. Error: %v", err)
@@ -312,8 +313,6 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 			w.toDelete.Range(func(key interface{}) bool {
 				w.lruMap.Remove(key)
 				w.toDelete.Remove(key)
-				w.workqueue.Forget(itemID)
-				w.workqueue.Done(itemID)
 				return true
 			})
 

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -294,6 +294,8 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 				item: item.(Item),
 			}})
 
+			// Since we create batches every time we sync, we will just remove the item from the queue here
+			// regardless of whether it succeeded the sync or not.
 			w.workqueue.Forget(itemID)
 			w.workqueue.Done(itemID)
 

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -313,6 +313,12 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 				}
 			}
 
+			w.toDelete.Range(func(key interface{}) bool {
+				w.lruMap.Remove(key)
+				w.toDelete.Remove(key)
+				return true
+			})
+
 			t.Stop()
 		}
 	}

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -235,6 +235,7 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 
 	for _, batch := range batches {
 		b := batch
+		logger.Infof(ctx, "Enqueuing batch with id: %v", b[0].GetID())
 		w.workqueue.Add(b[0].GetID())
 	}
 
@@ -281,6 +282,7 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 			t := w.metrics.SyncLatency.Start()
 			item, ok := w.lruMap.Get(itemId)
 			if !ok {
+				logger.Infof(ctx, "item with id [%v] not found in cache", itemId)
 				return nil
 			}
 			updatedBatch, err := w.syncCb(ctx, Batch{item.(ItemWrapper)})

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -293,8 +293,8 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 				item: item.(Item),
 			}})
 
-			w.workqueue.Forget(item)
-			w.workqueue.Done(item)
+			w.workqueue.Forget(itemID)
+			w.workqueue.Done(itemID)
 
 			if err != nil {
 				w.metrics.SyncErrors.Inc()

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -235,7 +235,7 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 
 	for _, batch := range batches {
 		for _, b := range batch {
-			logger.Debugf(ctx, "Enqueuing batch with id: %v", b.GetID())
+			logger.Infof(ctx, "Enqueuing batch with id: %v", b.GetID())
 			w.workqueue.Add(b.GetID())
 		}
 	}
@@ -277,10 +277,12 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 		default:
 			itemID, shutdown := w.workqueue.Get()
 			if shutdown {
+				logger.Infof(ctx, "Shutting down worker")
 				return nil
 			}
 
 			t := w.metrics.SyncLatency.Start()
+			logger.Infof(ctx, "Syncing item with id [%v]", itemID)
 			item, ok := w.lruMap.Get(itemID)
 			if !ok {
 				logger.Debugf(ctx, "item with id [%v] not found in cache", itemID)

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -235,7 +235,7 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 
 	for _, batch := range batches {
 		b := batch
-		logger.Infof(ctx, "Enqueuing batch with id: %v", b[0].GetID())
+		logger.Debugf(ctx, "Enqueuing batch with id: %v", b[0].GetID())
 		w.workqueue.Add(b[0].GetID())
 	}
 
@@ -282,7 +282,7 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 			t := w.metrics.SyncLatency.Start()
 			item, ok := w.lruMap.Get(itemId)
 			if !ok {
-				logger.Infof(ctx, "item with id [%v] not found in cache", itemId)
+				logger.Debugf(ctx, "item with id [%v] not found in cache", itemId)
 				return nil
 			}
 			updatedBatch, err := w.syncCb(ctx, Batch{itemWrapper{

--- a/cache/auto_refresh.go
+++ b/cache/auto_refresh.go
@@ -234,9 +234,10 @@ func (w *autoRefresh) enqueueBatches(ctx context.Context) error {
 	}
 
 	for _, batch := range batches {
-		b := batch
-		logger.Debugf(ctx, "Enqueuing batch with id: %v", b[0].GetID())
-		w.workqueue.Add(b[0].GetID())
+		for _, b := range batch {
+			logger.Debugf(ctx, "Enqueuing batch with id: %v", b.GetID())
+			w.workqueue.Add(b.GetID())
+		}
 	}
 
 	return nil
@@ -274,26 +275,26 @@ func (w *autoRefresh) sync(ctx context.Context) (err error) {
 		case <-ctx.Done():
 			return nil
 		default:
-			itemId, shutdown := w.workqueue.Get()
+			itemID, shutdown := w.workqueue.Get()
 			if shutdown {
 				return nil
 			}
 
 			t := w.metrics.SyncLatency.Start()
-			item, ok := w.lruMap.Get(itemId)
+			item, ok := w.lruMap.Get(itemID)
 			if !ok {
-				logger.Debugf(ctx, "item with id [%v] not found in cache", itemId)
+				logger.Debugf(ctx, "item with id [%v] not found in cache", itemID)
 				return nil
 			}
 			updatedBatch, err := w.syncCb(ctx, Batch{itemWrapper{
-				id:   itemId.(ItemID),
+				id:   itemID.(ItemID),
 				item: item.(Item),
 			}})
 
 			// Since we create batches every time we sync, we will just remove the item from the queue here
 			// regardless of whether it succeeded the sync or not.
-			w.workqueue.Forget(item)
-			w.workqueue.Done(item)
+			w.workqueue.Forget(itemID)
+			w.workqueue.Done(itemID)
 
 			if err != nil {
 				w.metrics.SyncErrors.Inc()


### PR DESCRIPTION
# TL;DR
I found that Propeller keeps sending the request to the agent even workflow is done.

The work queue only has unique items, so we add `itemID` to it. The workers won't process the item again after the task is done. 

Before:
||enqueueBatches| workqueue | sync (10 workers) |
|----|----|-----|----|
| t1 | obj(1) | obj(1) |  |
| t2 |  |  |  |
| t3 | obj(2)  |  obj(1), obj(2) |  |
| t4 |  |  |  |
| t5 | obj(1) | obj(1), obj(2), obj(1) |  |
| t6 |  |  | obj(1), obj(2), obj(1) |

After:
||enqueueBatches| workqueue | sync (10 workers) |
|----|----|-----|----|
| t1 | 1 | 1 |  |
| t2 |  |  |  |
| t3 | 2  |  1, 2 |  |
| t4 |  |  |  |
| t5 | 1 | 1, 2 |  |
| t6 |  |  | 1, 2 |



100 workflows, each has 100 tasks.
Before:
<img width="848" alt="image" src="https://github.com/flyteorg/flytestdlib/assets/37936015/13c8c06c-87ec-4909-898b-e06e298a54f7">

After:
<img width="854" alt="image" src="https://github.com/flyteorg/flytestdlib/assets/37936015/3e2043af-296b-4592-a1c4-d4cfe3c2cfed">


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_